### PR TITLE
Update README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ git clone https://github.com/conda-incubator/conda-self
 cd conda-self
 ```
 
-3. Create a `conda` environment with `conda-self`, `python` and `pip` in it.
+3. Create a `conda` environment with `python` and `pip` in it.
 ```
 conda create -n conda-self-dev python pip
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ pip install -e .
 
 1. Fork and clone this repository.
 ```
-git clone https://github.com/conda-incubator/conda-self`
+git clone https://github.com/conda-incubator/conda-self
 ```
 2. Change to that directory. 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,78 @@
 
 You'll need a copy of `pixi` and `git` in your machine. Then:
 
-1. Clone this repo to disk.
+1. Fork and clone this repo to disk.
 2. `pixi run test` to run the tests. Choose your desired Python version by picking the adequate environment.
 3. `pixi run lint` to run the pre-commit linters and formatters.
 4. `pixi run docs` to build the docs and `pixi run serve` to serve them in your browser.
+
+## Try it locally
+
+### With `pixi`
+
+1. Make sure `pixi` and `git` are installed. [Instructions for `pixi`](https://pixi.sh/latest/installation/).
+2. Clone this repository. 
+```
+git clone https://github.com/conda-incubator/conda-self
+```
+3. Change to that directory. 
+```
+cd conda-self
+```
+4. Run the help message. 
+```
+pixi run conda self --help
+```
+
+We _could_ just use the default pixi env to try things, but it doesn't write a good `history` file, so `conda self` will misunderstand what to do and remove everything sometimes. For now, let's use this default conda to create a demo environment to do things with:
+
+1. Create a demo environment with `conda` and `pip`.
+```
+pixi run conda create -p .pixi/envs/demo conda pip
+```
+2. If you have `conda spawn` installed,pseudo-activate it.
+```
+conda spawn ./.pixi/envs/demo
+```  
+If not, simply activate the environment.
+```
+conda activate .pixi/envs/demo
+```
+3. Install conda-self in it. 
+```
+pip install -e .
+```
+4. Play with `python -m conda self`.
+   1. `python -m conda self install numpy`
+   2. `python -m conda self install conda-rich`
+   3. `python -m conda self update`
+   4. `python -m conda self remove conda-rich`
+
+### With `conda` only
+
+1. Fork and clone this repository.
+```
+git clone https://github.com/conda-incubator/conda-self`
+```
+2. Change to that directory. 
+```
+cd conda-self
+```
+
+3. Create a `conda` environment with `conda-self`, `python` and `pip` in it.
+```
+conda create -n conda-self-dev conda-self --only-deps python pip
+```
+4. Activate the environment.
+```
+conda activate conda-self-dev
+```
+5. `pip` install the package.
+```
+python -m pip install -e . --no-deps
+```
+6. Play with `python -m conda self`
+   1. `python -m conda self install numpy`
+   2. `python -m conda self install conda-rich`
+   3. `python -m conda self update`
+   4. `python -m conda self remove conda-rich`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ If not, simply activate the environment.
 ```
 conda activate .pixi/envs/demo
 ```
-3. Install conda-self in it. 
+3. Install `conda-self` in it. 
 ```
 pip install -e .
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,6 @@
 # How to Contribute
 
-## Try it locally
-
-### With `pixi`
+## With `pixi`
 
 1. Make sure `pixi` and `git` are installed. [Instructions for `pixi`](https://pixi.sh/latest/installation/).
 2. Clone this repository. 
@@ -42,13 +40,13 @@ pip install -e .
    3. `python -m conda self update`
    4. `python -m conda self remove conda-rich`
 
-#### Included Tasks
+### Included Tasks
 
 1. `pixi run test` to run the tests. Choose your desired Python version by picking the adequate environment.
 2. `pixi run lint` to run the pre-commit linters and formatters.
 3. `pixi run docs` to build the docs and `pixi run serve` to serve them in your browser.
 
-### With `conda` only
+## With `conda` only
 
 1. Fork and clone this repository.
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ We _could_ just use the default pixi env to try things, but it doesn't write a g
 ```
 pixi run conda create -p .pixi/envs/demo conda pip
 ```
-2. If you have `conda spawn` installed,pseudo-activate it.
+2. `conda-spawn` is included in the pixi configuration, which you can use to pseudo-activate the environment:
 ```
 conda spawn ./.pixi/envs/demo
 ```  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ pixi run conda create -p .pixi/envs/demo conda pip
 ```
 2. `conda-spawn` is included in the pixi configuration, which you can use to pseudo-activate the environment:
 ```
-conda spawn ./.pixi/envs/demo
+pixi run conda spawn ./.pixi/envs/demo
 ```  
 If not, simply activate the environment.
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,11 +62,12 @@ cd conda-self
 
 3. Create a `conda` environment with `conda-self`, `python` and `pip` in it.
 ```
-conda create -n conda-self-dev conda-self --only-deps python pip
+conda create -n conda-self-dev python pip
 ```
-4. Activate the environment.
+4. Activate the environment and install `conda self`.
 ```
 conda activate conda-self-dev
+conda install conda-self --only-deps
 ```
 5. `pip` install the package.
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,9 +35,9 @@ conda activate .pixi/envs/demo
 pip install -e .
 ```
 4. Play with `python -m conda self`.
-   1. `python -m conda self install numpy`
-   2. `python -m conda self install conda-rich`
-   3. `python -m conda self update`
+   1. `python -m conda self update`
+   2. `python -m conda self install numpy`
+   3. `python -m conda self install conda-rich` 
    4. `python -m conda self remove conda-rich`
 
 ### Included Tasks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,4 @@
-# How to contribute
-
-You'll need a copy of `pixi` and `git` in your machine. Then:
-
-1. Fork and clone this repo to disk.
-2. `pixi run test` to run the tests. Choose your desired Python version by picking the adequate environment.
-3. `pixi run lint` to run the pre-commit linters and formatters.
-4. `pixi run docs` to build the docs and `pixi run serve` to serve them in your browser.
+# How to Contribute
 
 ## Try it locally
 
@@ -48,6 +41,12 @@ pip install -e .
    2. `python -m conda self install conda-rich`
    3. `python -m conda self update`
    4. `python -m conda self remove conda-rich`
+
+#### Included Tasks
+
+1. `pixi run test` to run the tests. Choose your desired Python version by picking the adequate environment.
+2. `pixi run lint` to run the pre-commit linters and formatters.
+3. `pixi run docs` to build the docs and `pixi run serve` to serve them in your browser.
 
 ### With `conda` only
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 A `self` command to manage your `base` environment safely.
 
+The `conda self` plugin provides two main subcommands, `protect` and `reset`: 
+
+- The `protect` subcommand lets you "freeze" your `base` environment so that you can't accidentally modify it. 
+- The `reset` subcommand lets you "reset" your `base` environment to only contain the essential packages. Others are deleted and the `base` environment is returned to an "unbloated" state. 
+
+Both `protect` and `reset` save the current state of the base environment in a `conda-meta/explicit.<time-stamp>.txt` file. 
+
 ```
 $ conda self
 usage: conda self [-V] [-h] {install,protect,remove,reset,update} ...
@@ -20,24 +27,10 @@ subcommands:
     reset               Reset 'base' environment to essential packages only.
     update              Update 'conda' and/or its plugins in the 'base' environment.
 ```
+## Installation
 
-## Try it locally
-
-1. Make sure `pixi` and `git` are installed. [Instructions for `pixi`](https://pixi.sh/latest/installation/).
-2. Clone this repository: `git clone https://github.com/conda-incubator/conda-self`
-3. Change to that directory: `cd conda-self`
-4. Run the help message: `pixi run conda self --help`
-
-We _could_ just use the default pixi env to try things, but it doesn't write a good `history` file, so `conda self` will misunderstand what to do and remove everything sometimes. For now, let's use this default conda to create a demo environment to do things with:
-
-1. Create a demo environment with `conda` and `pip`: `pixi run conda create -p .pixi/envs/demo conda pip`
-2. Pseudo-activate it: `conda spawn ./.pixi/envs/demo`.
-3. Install conda-self in it `pip install -e .`
-4. Play with `python -m conda self`
-   1. `python -m conda self install numpy`
-   2. `python -m conda self install conda-rich`
-   3. `python -m conda self update`
-   4. `python -m conda self remove conda-rich`
+1. `conda install -n base conda-self`
+2. `conda self --help`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,6 @@
 
 A `self` command to manage your `base` environment safely.
 
-The `conda self` plugin provides two main subcommands, `protect` and `reset`: 
-
-- The `protect` subcommand lets you "freeze" your `base` environment so that you can't accidentally modify it. 
-- The `reset` subcommand lets you "reset" your `base` environment to only contain the essential packages. Others are deleted and the `base` environment is returned to an "unbloated" state. 
-
-Both `protect` and `reset` save the current state of the base environment in a `conda-meta/explicit.<time-stamp>.txt` file. 
-
 ```
 $ conda self
 usage: conda self [-V] [-h] {install,protect,remove,reset,update} ...


### PR DESCRIPTION
Resolves #24 

- [x] Move local installation instructions `contributing.md`.
- [x] Add regular installation instructions.
- [x] Add that `spawn` is a plugin that users need to install and not one of the regular available conda commands.

