### PR TITLE
Refactor `conda migrate` command to support subcommands and enhance help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # conda-self
 
-A `self` command to manage your `base` environment safely.
+Commands to manage your `base` environment safely.
+
+## `conda self`
+
+Manage your conda 'base' environment safely.
 
 ```
 $ conda self
@@ -20,10 +24,44 @@ subcommands:
     reset               Reset 'base' environment to essential packages only.
     update              Update 'conda' and/or its plugins in the 'base' environment.
 ```
+
+## `conda migrate`
+
+Perform migration tasks for conda environments and configuration.
+
+```
+$ conda migrate
+Perform migration tasks for conda environments and configuration.
+
+The migrate command helps you transition your conda setup to follow best
+practices. Each migration task is a one-time operation that improves your
+conda workflow.
+
+Use `conda migrate --list` to see available migration tasks.
+
+Available migration tasks:
+
+  base    Protect `base` from accidental modifications and provide a modifiable
+          copy that will be configured as default.
+
+Run 'conda migrate <task> --help' for more information on a specific task.
+```
+
+### `conda migrate base`
+
+Migrate your base environment to follow best practices by creating a duplicate
+environment for daily use while protecting the base environment from accidental
+modifications.
+
+```
+$ conda migrate base --help
+```
+
 ## Installation
 
 1. `conda install -n base conda-self`
 2. `conda self --help`
+3. `conda migrate --help`
 
 ## Contributing
 

--- a/conda_self/cli/main_migrate.py
+++ b/conda_self/cli/main_migrate.py
@@ -1,14 +1,36 @@
 from __future__ import annotations
 
+import argparse
 from textwrap import dedent
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
-    import argparse
+    from collections.abc import Callable
 
-HELP = (
-    "Protect `base` from accidental modifications and provide a modifiable copy "
-    "that will be configured as default."
+
+class MigrationTask(NamedTuple):
+    """A migration task definition."""
+
+    name: str
+    help: str
+    configure_parser: Callable[[argparse.ArgumentParser], None]
+
+
+HELP = dedent(
+    """
+    Perform migration tasks for conda environments and configuration.
+
+    The migrate command helps you transition your conda setup to follow best
+    practices. Each migration task is a one-time operation that improves your
+    conda workflow.
+
+    Use `conda migrate --list` to see available migration tasks.
+    """
+).lstrip()
+
+BASE_HELP = (
+    "Protect the `base` environment from accidental modifications and provide a "
+    "modifiable copy that will be configured as default."
 )
 WHAT_TO_EXPECT = dedent(
     """
@@ -49,10 +71,10 @@ BEST_PRACTICES = dedent(
 ).lstrip()
 
 
-def configure_parser(parser: argparse.ArgumentParser) -> None:
+def configure_parser_base(parser: argparse.ArgumentParser) -> None:
     from conda.cli.helpers import add_output_and_prompt_options
 
-    parser.description = HELP
+    parser.description = BASE_HELP
     parser.add_argument(
         "--default-env",
         action="store",
@@ -66,10 +88,10 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         help="Optional message to add to the `conda-meta/frozen` file",
     )
     add_output_and_prompt_options(parser)
-    parser.set_defaults(func=execute)
+    parser.set_defaults(func=execute_base)
 
 
-def execute(args: argparse.Namespace) -> int:
+def execute_base(args: argparse.Namespace) -> int:
     import json
     import sys
     from contextlib import redirect_stdout
@@ -169,3 +191,65 @@ def execute(args: argparse.Namespace) -> int:
         print(SUCCESS_MESSAGE.format(env_name=args.default_env))
         print(BEST_PRACTICES)
     return 0
+
+
+# Registry of available migration tasks
+# TODO: Replace this with a plugin hook to allow external packages to register
+# migration tasks dynamically
+MIGRATION_TASKS = [
+    MigrationTask(
+        name="base",
+        help=BASE_HELP,
+        configure_parser=configure_parser_base,
+    ),
+]
+
+
+def _print_task_list() -> None:
+    """Print the list of available migration tasks."""
+    print("Available migration tasks:")
+    print()
+    for task in MIGRATION_TASKS:
+        print(f"  {task.name:<6}  {task.help}")
+
+
+def configure_parser(parser: argparse.ArgumentParser) -> None:
+    from conda.cli.helpers import add_output_and_prompt_options
+
+    parser.description = HELP
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List all available migration tasks",
+    )
+    add_output_and_prompt_options(parser)
+
+    subparsers = parser.add_subparsers(
+        title="migration tasks",
+        dest="task",
+    )
+
+    for task in MIGRATION_TASKS:
+        task.configure_parser(subparsers.add_parser(task.name, help=task.help))
+
+
+def execute(args: argparse.Namespace) -> int:
+    from conda.base.context import context
+
+    if args.list:
+        if context.json:
+            from conda.cli.common import stdout_json
+
+            stdout_json(
+                [{"name": task.name, "help": task.help} for task in MIGRATION_TASKS]
+            )
+        else:
+            _print_task_list()
+        return 0
+
+    # If no subcommand was provided, show error and help
+    if not hasattr(args, "func"):
+        parser = argparse.ArgumentParser(prog="conda migrate")
+        parser.error("the following arguments are required: task")
+
+    return args.func(args)

--- a/conda_self/plugin.py
+++ b/conda_self/plugin.py
@@ -26,5 +26,5 @@ def conda_subcommands() -> Iterable[plugins.CondaSubcommand]:
         name="migrate",
         action=main_migrate.execute,
         configure_parser=main_migrate.configure_parser,
-        summary="Protect and migrate your 'base' environment to a new one.",
+        summary="Perform migration tasks for conda environments and configuration.",
     )

--- a/news/migrate-base.md
+++ b/news/migrate-base.md
@@ -1,0 +1,9 @@
+### Enhancements
+
+* Refactored `conda migrate` command to support subcommands. The base environment migration functionality is now available via `conda migrate base`. This allows for future expansion with additional migration tasks.
+* Added `--list` option to `conda migrate` to display all available migration tasks.
+* Enhanced help text for the migrate command with a clear explanation of its purpose.
+
+### Deprecations
+
+* The `conda migrate` command now requires a subcommand. Users should use `conda migrate base` instead of `conda migrate` to migrate the base environment.

--- a/tests/test_cli_migrate.py
+++ b/tests/test_cli_migrate.py
@@ -13,6 +13,17 @@ def test_help(conda_cli):
     assert exc.value.code == 0
 
 
+def test_help_base(conda_cli):
+    out, err, exc = conda_cli("migrate", "base", "--help", raises=SystemExit)
+    assert exc.value.code == 0
+
+
+def test_list(conda_cli):
+    out, err, exc = conda_cli("migrate", "--list")
+    assert "Available migration tasks:" in out
+    assert "base" in out
+
+
 def test_migrate(conda_cli, mocker: MockerFixture, tmpdir: Path, monkeypatch):
     # Set the root prefix to the temporary directory
     monkeypatch.setenv("CONDA_ROOT_PREFIX", str(tmpdir))
@@ -48,6 +59,7 @@ def test_migrate(conda_cli, mocker: MockerFixture, tmpdir: Path, monkeypatch):
 
     out, err, exc = conda_cli(
         "migrate",
+        "base",
         "--default-env",
         new_default_env,
         "--yes",


### PR DESCRIPTION
Fix #74.

- Introduced `conda migrate base` for base environment migration.
- Added `--list` option to display available migration tasks.
- Updated documentation and README to reflect new command structure.
- Enhanced tests for new functionality and help commands.