### PR TITLE
Fix `conda self update` package conflicts on older Python

### DIFF
--- a/conda_self/cli/main_update.py
+++ b/conda_self/cli/main_update.py
@@ -34,11 +34,10 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
 
 def execute(args: argparse.Namespace) -> int:
     from conda.base.context import context
-    from conda.exceptions import DryRunExit
-    from conda.reporters import get_spinner
+    from conda.core.prefix_data import PrefixData
+    from conda.exceptions import PackageNotInstalledError
 
-    from ..install import install_package_list_in_protected_env
-    from ..query import check_updates
+    from ..install import install_specs_in_protected_env
     from ..validate import conda_plugin_packages, validate_plugin_is_installed
 
     if args.plugin:
@@ -49,40 +48,30 @@ def execute(args: argparse.Namespace) -> int:
     else:
         package_names = ["conda"]
 
-    updates = {}
+    prefix_data = PrefixData(context.root_prefix)
+
+    # Look up installed records for channel detection and status display.
     channel = ""
-    for package_name in package_names:
-        with get_spinner(f"Checking updates for {package_name}"):
-            update_available, installed, latest = check_updates(
-                package_name, context.root_prefix
-            )
+    info_parts = []
+    for name in package_names:
+        installed = prefix_data.get(name)
+        if not installed:
+            raise PackageNotInstalledError(context.root_prefix, name)
         if not channel:
             channel = installed.channel
+        info_parts.append(f"{name} (installed: {installed.version})")
 
-        if not context.quiet:
-            print(f"Installed {package_name}: {installed.version}")
-            print(f"Latest {package_name}: {latest.version}")
+    if not context.quiet:
+        print(f"Updating {', '.join(info_parts)}...")
+        print("Channels:")
+        print(f"  - {channel}")
 
-        if not update_available and not args.force_reinstall and not args.all:
-            print(f"{package_name} is already using the latest version available!")
-        else:
-            if not update_available and args.all:
-                print(
-                    f"{package_name} is using the latest version available, "
-                    "but may have outdated dependencies."
-                )
-            updates[package_name] = latest.version
-
-    if context.dry_run:
-        raise DryRunExit()
-    elif not updates:
-        return 0
-
-    return install_package_list_in_protected_env(
-        packages=updates,
+    return install_specs_in_protected_env(
+        specs=package_names,
         channel=channel,
         force_reinstall=args.force_reinstall,
         update_dependencies=args.all,
+        dry_run=context.dry_run,
         json=context.json,
         yes=context.always_yes,
     )

--- a/conda_self/install.py
+++ b/conda_self/install.py
@@ -4,32 +4,15 @@ from subprocess import run
 from conda.base.context import context
 
 
-def install_package_in_protected_env(
-    package_name: str,
-    package_version: str,
+def install_specs_in_protected_env(
+    specs: list[str],
     channel: str,
     force_reinstall: bool = False,
     update_dependencies: bool = False,
-    json: bool = False,
-) -> int:
-    return install_package_list_in_protected_env(
-        {package_name: package_version},
-        channel,
-        force_reinstall=force_reinstall,
-        update_dependencies=update_dependencies,
-        json=json,
-    )
-
-
-def install_package_list_in_protected_env(
-    packages: dict[str, str],
-    channel: str,
-    force_reinstall: bool = False,
-    update_dependencies: bool = False,
+    dry_run: bool = False,
     json: bool = False,
     yes: bool = False,
 ) -> int:
-    specs = [f"{name}={version}" for name, version in packages.items()]
     process = run(
         [
             sys.executable,
@@ -43,6 +26,7 @@ def install_package_list_in_protected_env(
                 else ()
             ),
             *(("--force-reinstall",) if force_reinstall else ()),
+            *(("--dry-run",) if dry_run else ()),
             *(("--json",) if json else ()),
             *(("--yes",) if yes else ()),
             "--all" if update_dependencies else "--update-specs",

--- a/conda_self/query.py
+++ b/conda_self/query.py
@@ -1,67 +1,16 @@
-""" """
+"""Queries for package dependency information."""
 
 from __future__ import annotations
 
 import sys
 from contextlib import suppress
-from typing import TYPE_CHECKING
 
-from conda.base.context import context
 from conda.core.prefix_data import PrefixData
-from conda.core.subdir_data import SubdirData
-from conda.exceptions import (
-    PackageNotInstalledError,
-    PackagesNotFoundError,
-)
-from conda.models.channel import Channel
 from conda.models.prefix_graph import PrefixGraph
-from conda.models.version import VersionOrder
 
 from .constants import PERMANENT_PACKAGES
 from .exceptions import NoDistInfoDirFound
 from .package_info import PackageInfo
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable
-
-    from conda.common.path import PathType
-    from conda.models.records import PackageRecord, PrefixRecord
-
-
-def check_updates(
-    package_name: str,
-    prefix: PathType = sys.prefix,
-) -> tuple[bool, PrefixRecord, PackageRecord]:
-    installed = PrefixData(prefix).get(package_name)
-    if not installed:
-        raise PackageNotInstalledError(prefix, package_name)
-
-    subdir = installed.subdir
-    subdirs = (subdir, (context.subdir if subdir == "noarch" else "noarch"))
-    latest_available = latest(installed.name, installed.channel.base_url, subdirs)
-    update_available = VersionOrder(latest_available.version) > VersionOrder(
-        installed.version
-    )
-
-    return update_available, installed, latest_available
-
-
-def latest(
-    package_name: str, channel_url: str, subdirs: Iterable[str]
-) -> PackageRecord:
-    best = None
-    max_version = VersionOrder("0.0.0dev0")
-    channels = []
-    for subdir in subdirs:
-        channel = Channel(f"{channel_url}/{subdir}")
-        channels.append(channel)
-        for record in SubdirData(channel).query(package_name):
-            if (record_version := VersionOrder(record.version)) > max_version:
-                best = record
-                max_version = record_version
-    if best is None:
-        raise PackagesNotFoundError(package_name, channels)
-    return best
 
 
 def permanent_dependencies(add_plugins: bool = False) -> set[str]:

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -3,19 +3,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-from conda import __version__ as conda_version
-from conda.exceptions import CondaValueError, DryRunExit
-from conda.models.channel import Channel
-from conda.models.records import PackageRecord
-from conda_libmamba_solver import __version__ as clms_version
+from conda.exceptions import CondaValueError
 
-from conda_self import query, validate
+from conda_self.testing import conda_cli_subprocess
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
-
-    from conda.testing.fixtures import CondaCLIFixture
-    from pytest_mock import MockerFixture
+    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
+    from pytest import MonkeyPatch
 
 
 def test_help(conda_cli: CondaCLIFixture):
@@ -23,136 +17,49 @@ def test_help(conda_cli: CondaCLIFixture):
     assert exc.value.code == 0
 
 
-@pytest.mark.parametrize(
-    "latest_version,message",
-    (
-        pytest.param(
-            "1",
-            "conda is already using the latest version available!",
-            id="Outdated",
-        ),
-        pytest.param(
-            conda_version,
-            "conda is already using the latest version available!",
-            id="Same",
-        ),
-        pytest.param(
-            "2040",
-            "Latest conda: 2040",
-            id="Updatable",
-        ),
-    ),
-)
-def test_update_conda(
-    conda_cli: CondaCLIFixture, mocker: MockerFixture, latest_version: str, message: str
-):
-    mocker.patch.object(
-        query,
-        "latest",
-        return_value=PackageRecord(
-            name="conda",
-            version=latest_version,
-            build="0",
-            build_number=0,
-            channel=Channel("conda-forge"),
-        ),
-    )
-    out, err, exc = conda_cli("self", "update", "--dry-run", raises=DryRunExit)
-    assert f"Installed conda: {conda_version}" in out
-    assert message in out
-
-
-@pytest.mark.parametrize(
-    "plugin_name,ok", (("conda-libmamba-solver", True), ("conda-fake-solver", False))
-)
-def test_update_plugin(
-    conda_cli: CondaCLIFixture, plugin_name: str, ok: tuple[str, bool]
-):
+def test_update_plugin_invalid(conda_cli: CondaCLIFixture):
     conda_cli(
-        "self",
-        "update",
-        "--dry-run",
-        "--plugin",
-        plugin_name,
-        raises=DryRunExit if ok else CondaValueError,
+        "self", "update", "--plugin", "conda-fake-solver", raises=CondaValueError
     )
 
 
 @pytest.mark.parametrize(
-    "latest_versions,message_parts",
+    "extra_args,expected",
     (
+        pytest.param((), "conda (installed:", id="conda"),
         pytest.param(
-            {
-                "conda": conda_version,
-                "conda-libmamba-solver": clms_version,
-            },
-            (
-                (
-                    "conda is using the latest version "
-                    "available, but may have outdated dependencies."
-                ),
-                (
-                    "conda-libmamba-solver is using the latest version "
-                    "available, but may have outdated dependencies."
-                ),
-            ),
-            id="No updates",
+            ("--plugin", "conda-libmamba-solver"),
+            "conda-libmamba-solver (installed:",
+            id="plugin",
         ),
+        pytest.param(("--all",), "conda (installed:", id="all"),
         pytest.param(
-            {
-                "conda": conda_version,
-                "conda-libmamba-solver": "2080",
-            },
-            (
-                (
-                    "conda is using the latest version "
-                    "available, but may have outdated dependencies."
-                ),
-                "Latest conda-libmamba-solver: 2080",
-            ),
-            id="Update one",
-        ),
-        pytest.param(
-            {
-                "conda": "2040",
-                "conda-libmamba-solver": "2080",
-            },
-            (
-                "Latest conda: 2040",
-                "Latest conda-libmamba-solver: 2080",
-            ),
-            id="Update all",
+            ("--all", "--force-reinstall"),
+            "conda (installed:",
+            id="all+force-reinstall",
         ),
     ),
 )
-def test_update_all(
-    conda_cli: CondaCLIFixture,
-    mocker: MockerFixture,
-    latest_versions: dict[str, str],
-    message_parts: tuple[str, ...],
+def test_update(
+    extra_args: tuple[str, ...],
+    expected: str,
+    monkeypatch: MonkeyPatch,
+    tmp_env: TmpEnvFixture,
+    conda_channel: str,
+    python_version: str,
 ):
-    def mock_latest(package_name: str, _: str, __: Iterable[str]) -> PackageRecord:
-        return PackageRecord(
-            name=package_name,
-            version=latest_versions.get(package_name),
-            build="0",
-            build_number=0,
-            channel=Channel("conda-forge"),
-        )
+    monkeypatch.setenv("CONDA_CHANNELS", conda_channel)
 
-    mocker.patch.object(
-        validate, "conda_plugin_packages", return_value=["conda-libmamba-solver"]
-    )
-    mocker.patch.object(query, "latest", mock_latest)
-    out, _, _ = conda_cli(
-        "self",
-        "update",
-        "--all",
-        "--dry-run",
-        raises=DryRunExit,
-    )
-    # Check that installed versions are reported (exact version may differ in canary)
-    assert "Installed conda:" in out
-    assert "Installed conda-libmamba-solver:" in out
-    for message in message_parts:
-        assert message in out
+    with tmp_env("conda", "conda-self", f"python={python_version}") as prefix:
+        result = conda_cli_subprocess(
+            prefix,
+            "self",
+            "update",
+            *extra_args,
+            "--dry-run",
+            "--yes",
+            capture_output=True,
+            text=True,
+        )
+        assert "Updating" in result.stdout
+        assert expected in result.stdout

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -18,9 +18,7 @@ def test_help(conda_cli: CondaCLIFixture):
 
 
 def test_update_plugin_invalid(conda_cli: CondaCLIFixture):
-    conda_cli(
-        "self", "update", "--plugin", "conda-fake-solver", raises=CondaValueError
-    )
+    conda_cli("self", "update", "--plugin", "conda-fake-solver", raises=CondaValueError)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes #85.

`conda self update` manually queries repodata to find the highest version number, then pins it for `conda install`. This bypasses the solver's compatibility checks — when the latest version doesn't support the current Python (e.g. 3.9 after conda-forge dropped it), the command fails with a solver error.

Drop the manual repodata query and version pinning. Pass unpinned package names to `conda install --update-specs` and let the solver find the latest compatible version.

## Changes

- `install.py`: Accept `specs: list[str]` instead of `dict[str, str]`, add `dry_run` passthrough, remove unused wrapper
- `main_update.py`: Get channel from `PrefixData` directly, show installed versions, pass unpinned specs to the solver
- `query.py`: Remove `check_updates()` and `latest()`, keep `permanent_dependencies()`
- Tests: Integration tests using `tmp_env` + `conda_cli_subprocess`