### PR TITLE
Document how to unprotect the base environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ To see all available health checks, run:
 conda doctor --list
 ```
 
+### Unprotecting base
+
+To remove protection entirely, delete the frozen file:
+
+```
+rm $CONDA_PREFIX/conda-meta/frozen
+```
+
+To bypass protection for a single command, pass `--override-frozen` or set
+`CONDA_OVERRIDE_FROZEN=1`. To disable it permanently, add `override_frozen: true`
+to your `.condarc`.
+
 ## Installation
 
 1. `conda install -n base conda-self`


### PR DESCRIPTION
Closes #51.

Unprotecting should stay intentionally manual rather than a first-class subcommand — adding a `protect --reverse` or similar would undo the design decision from #88/#91. The existing escape hatches cover all the real use cases:

- remove `conda-meta/frozen` directly
- `--override-frozen` per-command
- `CONDA_OVERRIDE_FROZEN=1` env var
- `override_frozen: true` in `.condarc`

Documents those in the README instead of adding new CLI surface.