### PR TITLE
Document custom channel configuration for plugin install

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ conda self install my-plugin
 This keeps channel configuration consistent across install, update, and
 dependency resolution.
 
+Inline channel specs (e.g. `conda-forge::my-plugin`) are not supported and
+will result in an error.
+
 ## Base Environment Protection
 
 To check if your base environment is protected, run:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ subcommands:
     update              Update 'conda' and/or its plugins in the 'base' environment.
 ```
 
+### Custom channels
+
+`conda self install` and `conda self update` use your configured channels.
+To install plugins from a custom channel (e.g. a company or community channel
+on anaconda.org or prefix.dev), add it to your configuration first:
+
+```
+conda config --add channels my-channel
+conda self install my-plugin
+```
+
+This keeps channel configuration consistent across install, update, and
+dependency resolution.
+
 ## Base Environment Protection
 
 To check if your base environment is protected, run:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To install plugins from a custom channel (e.g. a company or community channel
 on anaconda.org or prefix.dev), add it to your configuration first:
 
 ```
-conda config --add channels my-channel
+conda config --add channels my-channel -n base
 conda self install my-plugin
 ```
 


### PR DESCRIPTION
## Summary

Closes #36.

`conda self install` already uses configured channels, so a `--channel` flag isn't needed. This documents how to add custom channels (company/community channels on anaconda.org or prefix.dev) so they work consistently across install, update, and dependency resolution.