### PR TITLE
Reject channel specs in conda self install

### DIFF
--- a/conda_self/cli/main_install.py
+++ b/conda_self/cli/main_install.py
@@ -55,6 +55,14 @@ def execute(args: argparse.Namespace) -> int:
     else:
         specs_to_add = [MatchSpec(spec) for spec in args.specs]
 
+    specs_with_channels = [str(s) for s in specs_to_add if s.get("channel")]
+    if specs_with_channels:
+        joined = ", ".join(specs_with_channels)
+        raise CondaValueError(
+            f"Channel specifications are not supported: {joined}\n"
+            "Configure channels via `conda config --add channels <channel>` instead."
+        )
+
     solver = Solver(sys.prefix, context.channels, specs_to_add=specs_to_add)
     transaction = solver.solve_for_transaction()
 

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -1,5 +1,5 @@
 import pytest
-from conda.exceptions import DryRunExit, PackagesNotFoundError
+from conda.exceptions import CondaValueError, DryRunExit, PackagesNotFoundError
 
 from conda_self.exceptions import SpecsAreNotPlugins
 
@@ -41,3 +41,14 @@ def test_install_not_plugins(conda_cli, plugin_name, error):
         plugin_name,
         raises=error,
     )
+
+
+@pytest.mark.parametrize(
+    "spec",
+    (
+        "conda-forge::conda-libmamba-solver",
+        "defaults::conda-libmamba-solver",
+    ),
+)
+def test_install_channel_in_spec_rejected(conda_cli, spec):
+    conda_cli("self", "install", spec, raises=CondaValueError)


### PR DESCRIPTION
## Summary

Closes #104.

`conda self install conda-forge::some-plugin` would silently bypass the user's configured channel stack, potentially mixing channels. This raises a `CondaValueError` instead with a hint to configure the channel properly:

```
Channel specifications are not supported: conda-forge::some-plugin
Configure channels via `conda config --add channels <channel>` instead.
```

See also #117 which documents the recommended channel configuration workflow.