### PR TITLE
Fix conda self install bypassing frozen env protection

### DIFF
--- a/conda_self/cli/main_install.py
+++ b/conda_self/cli/main_install.py
@@ -52,7 +52,7 @@ def execute(args: argparse.Namespace) -> int:
     print("Installing plugins:", *args.specs)
 
     if context.dry_run:
-        # Use in-process solver for dry-run so PackagesNotFoundError propagates correctly
+        # Use in-process solver for dry-run so exceptions propagate correctly
         Solver(
             sys.prefix, context.channels, specs_to_add=specs_to_add
         ).solve_for_transaction()

--- a/conda_self/cli/main_install.py
+++ b/conda_self/cli/main_install.py
@@ -33,7 +33,10 @@ def execute(args: argparse.Namespace) -> int:
     from conda.models.match_spec import MatchSpec
 
     from ..exceptions import SpecsAreNotPlugins
-    from ..install import install_specs_in_protected_env, uninstall_specs_in_protected_env
+    from ..install import (
+        install_specs_in_protected_env,
+        uninstall_specs_in_protected_env,
+    )
     from ..validate import conda_plugin_packages, reload_plugin_packages
 
     specs_to_add = [MatchSpec(spec) for spec in args.specs]
@@ -50,7 +53,9 @@ def execute(args: argparse.Namespace) -> int:
 
     if context.dry_run:
         # Use in-process solver for dry-run so PackagesNotFoundError propagates correctly
-        Solver(sys.prefix, context.channels, specs_to_add=specs_to_add).solve_for_transaction()
+        Solver(
+            sys.prefix, context.channels, specs_to_add=specs_to_add
+        ).solve_for_transaction()
         raise DryRunExit()
 
     returncode = install_specs_in_protected_env(

--- a/conda_self/cli/main_install.py
+++ b/conda_self/cli/main_install.py
@@ -25,9 +25,6 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
 
 
 def execute(args: argparse.Namespace) -> int:
-    import sys
-
-    from conda.api import Solver
     from conda.base.context import context
     from conda.exceptions import CondaValueError, DryRunExit
     from conda.models.match_spec import MatchSpec
@@ -51,23 +48,19 @@ def execute(args: argparse.Namespace) -> int:
 
     print("Installing plugins:", *args.specs)
 
-    # Pre-flight solve: validates specs exist and raises PackagesNotFoundError early
-    Solver(
-        sys.prefix, context.channels, specs_to_add=specs_to_add
-    ).solve_for_transaction()
-
-    if context.dry_run:
-        raise DryRunExit()
-
     returncode = install_specs_in_protected_env(
         args.specs,
         force_reinstall=args.force_reinstall,
+        dry_run=context.dry_run,
         json=context.json,
         yes=context.always_yes,
     )
 
     if returncode != 0:
         return returncode
+
+    if context.dry_run:
+        raise DryRunExit()
 
     reload_plugin_packages()
 

--- a/conda_self/cli/main_install.py
+++ b/conda_self/cli/main_install.py
@@ -27,7 +27,7 @@ def execute(args: argparse.Namespace) -> int:
     from conda.exceptions import CondaValueError, DryRunExit
     from conda.models.match_spec import MatchSpec
 
-    from ..exceptions import NotPluginError
+    from ..exceptions import NotAPluginError
     from ..install import (
         install_specs_in_protected_env,
         uninstall_specs_in_protected_env,
@@ -72,6 +72,6 @@ def execute(args: argparse.Namespace) -> int:
 
     if invalid_names:
         uninstall_specs_in_protected_env(invalid_names, yes=True)
-        raise NotPluginError(invalid_names)
+        raise NotAPluginError(invalid_names)
 
     return 0

--- a/conda_self/cli/main_install.py
+++ b/conda_self/cli/main_install.py
@@ -27,7 +27,7 @@ def execute(args: argparse.Namespace) -> int:
     from conda.exceptions import CondaValueError, DryRunExit
     from conda.models.match_spec import MatchSpec
 
-    from ..exceptions import SpecsAreNotPlugins
+    from ..exceptions import NotPluginError
     from ..install import (
         install_specs_in_protected_env,
         uninstall_specs_in_protected_env,
@@ -72,6 +72,6 @@ def execute(args: argparse.Namespace) -> int:
 
     if invalid_names:
         uninstall_specs_in_protected_env(invalid_names, yes=True)
-        raise SpecsAreNotPlugins(invalid_names)
+        raise NotPluginError(invalid_names)
 
     return 0

--- a/conda_self/cli/main_install.py
+++ b/conda_self/cli/main_install.py
@@ -27,33 +27,16 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
 def execute(args: argparse.Namespace) -> int:
     import sys
 
-    from conda.api import PackageCacheData, Solver
+    from conda.api import Solver
     from conda.base.context import context
-    from conda.cli.common import stdout_json_success
-    from conda.common.path import is_package_file
-    from conda.core.package_cache_data import ProgressiveFetchExtract
     from conda.exceptions import CondaValueError, DryRunExit
-    from conda.misc import _match_specs_from_explicit
     from conda.models.match_spec import MatchSpec
-    from conda.reporters import confirm_yn
 
     from ..exceptions import SpecsAreNotPlugins
-    from ..package_info import NoDistInfoDirFound, PackageInfo
+    from ..install import install_specs_in_protected_env, uninstall_specs_in_protected_env
+    from ..validate import conda_plugin_packages, reload_plugin_packages
 
-    print("Installing plugins:", *args.specs)
-
-    specs_to_add = []
-
-    num_cp = sum(is_package_file(s) for s in args.specs)
-    if num_cp:
-        if num_cp == len(args.specs):
-            specs_to_add = list(_match_specs_from_explicit(args.specs))
-        else:
-            raise CondaValueError(
-                "cannot mix specifications with conda package filenames"
-            )
-    else:
-        specs_to_add = [MatchSpec(spec) for spec in args.specs]
+    specs_to_add = [MatchSpec(spec) for spec in args.specs]
 
     specs_with_channels = [str(s) for s in specs_to_add if s.get("channel")]
     if specs_with_channels:
@@ -63,47 +46,30 @@ def execute(args: argparse.Namespace) -> int:
             "Configure channels via `conda config --add channels <channel>` instead."
         )
 
-    solver = Solver(sys.prefix, context.channels, specs_to_add=specs_to_add)
-    transaction = solver.solve_for_transaction()
+    print("Installing plugins:", *args.specs)
 
-    # If it's a dry run we don't want to be downloading anything
     if context.dry_run:
-        actions = transaction._make_legacy_action_groups()[0]
-        stdout_json_success(prefix=sys.prefix, actions=actions, dry_run=True)
+        # Use in-process solver for dry-run so PackagesNotFoundError propagates correctly
+        Solver(sys.prefix, context.channels, specs_to_add=specs_to_add).solve_for_transaction()
         raise DryRunExit()
 
-    specs_to_add_names = [spec.name for spec in specs_to_add]
-    requested = [
-        record
-        for record in transaction.prefix_setups[sys.prefix].link_precs
-        if record.name in specs_to_add_names
-    ]
+    returncode = install_specs_in_protected_env(
+        args.specs,
+        force_reinstall=args.force_reinstall,
+        json=context.json,
+        yes=context.always_yes,
+    )
 
-    # Download requested
-    ProgressiveFetchExtract(requested).execute()
+    if returncode != 0:
+        return returncode
 
-    package_cache_records = [PackageCacheData.query_all(prec)[0] for prec in requested]
-    invalid_names = []
-    for pcr in package_cache_records:
-        try:
-            infos = PackageInfo.from_record(pcr)
-        except NoDistInfoDirFound:
-            invalid_names.append(pcr.name)
-        else:
-            if not any("conda" in info.entry_points().keys() for info in infos):
-                invalid_names.append(pcr.name)
+    reload_plugin_packages()
+
+    spec_names = [spec.name for spec in specs_to_add]
+    invalid_names = [name for name in spec_names if name not in conda_plugin_packages()]
 
     if invalid_names:
+        uninstall_specs_in_protected_env(invalid_names, yes=True)
         raise SpecsAreNotPlugins(invalid_names)
-
-    if not context.json:
-        transaction.print_transaction_summary()
-        confirm_yn()
-
-    transaction.execute()
-
-    if context.json:
-        actions = transaction._make_legacy_action_groups()[0]
-        stdout_json_success(prefix=sys.prefix, actions=actions)
 
     return 0

--- a/conda_self/cli/main_install.py
+++ b/conda_self/cli/main_install.py
@@ -62,8 +62,13 @@ def execute(args: argparse.Namespace) -> int:
 
     reload_plugin_packages()
 
+    plugin_names = conda_plugin_packages()
     spec_names = [spec.name for spec in specs_to_add]
-    invalid_names = [name for name in spec_names if name not in conda_plugin_packages()]
+    invalid_names = [
+        name
+        for name in spec_names
+        if name.lower().replace("_", "-") not in plugin_names
+    ]
 
     if invalid_names:
         uninstall_specs_in_protected_env(invalid_names, yes=True)

--- a/conda_self/cli/main_install.py
+++ b/conda_self/cli/main_install.py
@@ -51,11 +51,12 @@ def execute(args: argparse.Namespace) -> int:
 
     print("Installing plugins:", *args.specs)
 
+    # Pre-flight solve: validates specs exist and raises PackagesNotFoundError early
+    Solver(
+        sys.prefix, context.channels, specs_to_add=specs_to_add
+    ).solve_for_transaction()
+
     if context.dry_run:
-        # Use in-process solver for dry-run so exceptions propagate correctly
-        Solver(
-            sys.prefix, context.channels, specs_to_add=specs_to_add
-        ).solve_for_transaction()
         raise DryRunExit()
 
     returncode = install_specs_in_protected_env(

--- a/conda_self/cli/main_install.py
+++ b/conda_self/cli/main_install.py
@@ -9,16 +9,14 @@ HELP = "Add conda plugins to the 'base' environment."
 
 
 def configure_parser(parser: argparse.ArgumentParser) -> None:
+    from conda.cli.helpers import add_output_and_prompt_options
+
     parser.description = HELP
+    add_output_and_prompt_options(parser)
     parser.add_argument(
         "--force-reinstall",
         action="store_true",
         help="Reinstall plugin even if it's already installed.",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Only report available updates, do not install.",
     )
     parser.add_argument("specs", nargs="+", help="Plugins to install")
     parser.set_defaults(func=execute)

--- a/conda_self/cli/main_remove.py
+++ b/conda_self/cli/main_remove.py
@@ -21,7 +21,7 @@ def execute(args: argparse.Namespace) -> int:
     from conda.base.context import context
     from conda.reporters import confirm_yn
 
-    from ..exceptions import SpecsCanNotBeRemoved
+    from ..exceptions import PluginRemoveError
     from ..install import uninstall_specs_in_protected_env
     from ..query import permanent_dependencies
 
@@ -32,7 +32,7 @@ def execute(args: argparse.Namespace) -> int:
             invalid_specs.append(spec)
 
     if invalid_specs:
-        raise SpecsCanNotBeRemoved(invalid_specs)
+        raise PluginRemoveError(invalid_specs)
 
     print("Removing plugins:", *args.specs)
 

--- a/conda_self/cli/main_update.py
+++ b/conda_self/cli/main_update.py
@@ -34,11 +34,10 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
 
 def execute(args: argparse.Namespace) -> int:
     from conda.base.context import context
-    from conda.exceptions import DryRunExit
-    from conda.reporters import get_spinner
+    from conda.core.prefix_data import PrefixData
+    from conda.exceptions import PackageNotInstalledError
 
-    from ..install import install_package_list_in_protected_env
-    from ..query import check_updates
+    from ..install import install_specs_in_protected_env
     from ..validate import conda_plugin_packages, validate_plugin_is_installed
 
     if args.plugin:
@@ -49,40 +48,30 @@ def execute(args: argparse.Namespace) -> int:
     else:
         package_names = ["conda"]
 
-    updates = {}
+    prefix_data = PrefixData(context.root_prefix)
+
+    # Look up installed records for channel detection and status display.
     channel = ""
-    for package_name in package_names:
-        with get_spinner(f"Checking updates for {package_name}"):
-            update_available, installed, latest = check_updates(
-                package_name, context.root_prefix
-            )
+    info_parts = []
+    for name in package_names:
+        installed = prefix_data.get(name)
+        if not installed:
+            raise PackageNotInstalledError(context.root_prefix, name)
         if not channel:
             channel = installed.channel
+        info_parts.append(f"{name} (installed: {installed.version})")
 
-        if not context.quiet:
-            print(f"Installed {package_name}: {installed.version}")
-            print(f"Latest {package_name}: {latest.version}")
+    if not context.quiet:
+        print(f"Updating {', '.join(info_parts)}...")
+        print("Channels:")
+        print(f"  - {channel}")
 
-        if not update_available and not args.force_reinstall and not args.all:
-            print(f"{package_name} is already using the latest version available!")
-        else:
-            if not update_available and args.all:
-                print(
-                    f"{package_name} is using the latest version available, "
-                    "but may have outdated dependencies."
-                )
-            updates[package_name] = latest.version
-
-    if context.dry_run:
-        raise DryRunExit()
-    elif not updates:
-        return 0
-
-    return install_package_list_in_protected_env(
-        packages=updates,
+    return install_specs_in_protected_env(
+        specs=package_names,
         channel=channel,
         force_reinstall=args.force_reinstall,
         update_dependencies=args.all,
+        dry_run=context.dry_run,
         json=context.json,
         yes=context.always_yes,
     )

--- a/conda_self/cli/main_update.py
+++ b/conda_self/cli/main_update.py
@@ -50,25 +50,18 @@ def execute(args: argparse.Namespace) -> int:
 
     prefix_data = PrefixData(context.root_prefix)
 
-    # Look up installed records for channel detection and status display.
-    channel = ""
     info_parts = []
     for name in package_names:
         installed = prefix_data.get(name)
         if not installed:
             raise PackageNotInstalledError(context.root_prefix, name)
-        if not channel:
-            channel = installed.channel
         info_parts.append(f"{name} (installed: {installed.version})")
 
     if not context.quiet:
         print(f"Updating {', '.join(info_parts)}...")
-        print("Channels:")
-        print(f"  - {channel}")
 
     return install_specs_in_protected_env(
         specs=package_names,
-        channel=channel,
         force_reinstall=args.force_reinstall,
         update_dependencies=args.all,
         dry_run=context.dry_run,

--- a/conda_self/exceptions.py
+++ b/conda_self/exceptions.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-class NotPluginError(CondaError):
+class NotAPluginError(CondaError):
     def __init__(self, specs: list[str]):
         super().__init__(f"The following requested specs are not plugins: {specs}.")
 

--- a/conda_self/exceptions.py
+++ b/conda_self/exceptions.py
@@ -8,12 +8,12 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-class SpecsAreNotPlugins(CondaError):
+class NotPluginError(CondaError):
     def __init__(self, specs: list[str]):
         super().__init__(f"The following requested specs are not plugins: {specs}.")
 
 
-class SpecsCanNotBeRemoved(CondaError):
+class PluginRemoveError(CondaError):
     def __init__(self, specs: list[str]):
         super().__init__(f"Packages '{specs}' can not be removed.")
 

--- a/conda_self/install.py
+++ b/conda_self/install.py
@@ -6,19 +6,13 @@ from conda.base.context import context
 
 def install_specs_in_protected_env(
     specs: list[str],
-    channel: str = "",
     force_reinstall: bool = False,
     update_dependencies: bool = False,
     dry_run: bool = False,
     json: bool = False,
     yes: bool = False,
 ) -> int:
-    """Install or update specs into the protected base env via subprocess.
-
-    When channel is given, restricts resolution to that channel via
-    --override-channels (used by `conda self update`). Otherwise uses
-    configured channels (used by `conda self install`).
-    """
+    """Install or update specs into the protected base env via subprocess."""
     process = run(
         [
             sys.executable,
@@ -36,7 +30,6 @@ def install_specs_in_protected_env(
             *(("--json",) if json else ()),
             *(("--yes",) if yes else ()),
             "--all" if update_dependencies else "--update-specs",
-            *(("--override-channels", f"--channel={channel}") if channel else ()),
             *specs,
         ]
     )

--- a/conda_self/install.py
+++ b/conda_self/install.py
@@ -68,7 +68,11 @@ def install_specs_in_protected_env(
             "conda",
             "install",
             f"--prefix={sys.prefix}",
-            *(("--override-frozen",) if hasattr(context, "protect_frozen_envs") else ()),
+            *(
+                ("--override-frozen",)
+                if hasattr(context, "protect_frozen_envs")
+                else ()
+            ),
             *(("--force-reinstall",) if force_reinstall else ()),
             *(("--json",) if json else ()),
             *(("--yes",) if yes else ()),

--- a/conda_self/install.py
+++ b/conda_self/install.py
@@ -4,32 +4,15 @@ from subprocess import run
 from conda.base.context import context
 
 
-def install_package_in_protected_env(
-    package_name: str,
-    package_version: str,
+def install_specs_in_protected_env(
+    specs: list[str],
     channel: str,
     force_reinstall: bool = False,
     update_dependencies: bool = False,
-    json: bool = False,
-) -> int:
-    return install_package_list_in_protected_env(
-        {package_name: package_version},
-        channel,
-        force_reinstall=force_reinstall,
-        update_dependencies=update_dependencies,
-        json=json,
-    )
-
-
-def install_package_list_in_protected_env(
-    packages: dict[str, str],
-    channel: str,
-    force_reinstall: bool = False,
-    update_dependencies: bool = False,
+    dry_run: bool = False,
     json: bool = False,
     yes: bool = False,
 ) -> int:
-    specs = [f"{name}={version}" for name, version in packages.items()]
     process = run(
         [
             sys.executable,
@@ -43,6 +26,7 @@ def install_package_list_in_protected_env(
                 else ()
             ),
             *(("--force-reinstall",) if force_reinstall else ()),
+            *(("--dry-run",) if dry_run else ()),
             *(("--json",) if json else ()),
             *(("--yes",) if yes else ()),
             "--all" if update_dependencies else "--update-specs",

--- a/conda_self/install.py
+++ b/conda_self/install.py
@@ -57,6 +57,7 @@ def install_package_list_in_protected_env(
 def install_specs_in_protected_env(
     specs: list[str],
     force_reinstall: bool = False,
+    dry_run: bool = False,
     json: bool = False,
     yes: bool = False,
 ) -> int:
@@ -74,6 +75,7 @@ def install_specs_in_protected_env(
                 else ()
             ),
             *(("--force-reinstall",) if force_reinstall else ()),
+            *(("--dry-run",) if dry_run else ()),
             *(("--json",) if json else ()),
             *(("--yes",) if yes else ()),
             *specs,

--- a/conda_self/install.py
+++ b/conda_self/install.py
@@ -54,6 +54,30 @@ def install_package_list_in_protected_env(
     return process.returncode
 
 
+def install_specs_in_protected_env(
+    specs: list[str],
+    force_reinstall: bool = False,
+    json: bool = False,
+    yes: bool = False,
+) -> int:
+    """Install new specs (without pinned versions) into the protected base env."""
+    process = run(
+        [
+            sys.executable,
+            "-m",
+            "conda",
+            "install",
+            f"--prefix={sys.prefix}",
+            *(("--override-frozen",) if hasattr(context, "protect_frozen_envs") else ()),
+            *(("--force-reinstall",) if force_reinstall else ()),
+            *(("--json",) if json else ()),
+            *(("--yes",) if yes else ()),
+            *specs,
+        ]
+    )
+    return process.returncode
+
+
 def uninstall_specs_in_protected_env(
     specs: list[str],
     json: bool = False,

--- a/conda_self/query.py
+++ b/conda_self/query.py
@@ -1,67 +1,16 @@
-""" """
+"""Queries for package dependency information."""
 
 from __future__ import annotations
 
 import sys
 from contextlib import suppress
-from typing import TYPE_CHECKING
 
-from conda.base.context import context
 from conda.core.prefix_data import PrefixData
-from conda.core.subdir_data import SubdirData
-from conda.exceptions import (
-    PackageNotInstalledError,
-    PackagesNotFoundError,
-)
-from conda.models.channel import Channel
 from conda.models.prefix_graph import PrefixGraph
-from conda.models.version import VersionOrder
 
 from .constants import PERMANENT_PACKAGES
 from .exceptions import NoDistInfoDirFound
 from .package_info import PackageInfo
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable
-
-    from conda.common.path import PathType
-    from conda.models.records import PackageRecord, PrefixRecord
-
-
-def check_updates(
-    package_name: str,
-    prefix: PathType = sys.prefix,
-) -> tuple[bool, PrefixRecord, PackageRecord]:
-    installed = PrefixData(prefix).get(package_name)
-    if not installed:
-        raise PackageNotInstalledError(prefix, package_name)
-
-    subdir = installed.subdir
-    subdirs = (subdir, (context.subdir if subdir == "noarch" else "noarch"))
-    latest_available = latest(installed.name, installed.channel.base_url, subdirs)
-    update_available = VersionOrder(latest_available.version) > VersionOrder(
-        installed.version
-    )
-
-    return update_available, installed, latest_available
-
-
-def latest(
-    package_name: str, channel_url: str, subdirs: Iterable[str]
-) -> PackageRecord:
-    best = None
-    max_version = VersionOrder("0.0.0dev0")
-    channels = []
-    for subdir in subdirs:
-        channel = Channel(f"{channel_url}/{subdir}")
-        channels.append(channel)
-        for record in SubdirData(channel).query(package_name):
-            if (record_version := VersionOrder(record.version)) > max_version:
-                best = record
-                max_version = record_version
-    if best is None:
-        raise PackagesNotFoundError(package_name, channels)
-    return best
 
 
 def permanent_dependencies(add_plugins: bool = False) -> set[str]:

--- a/conda_self/validate.py
+++ b/conda_self/validate.py
@@ -9,16 +9,23 @@ else:
     from importlib_metadata import entry_points
 
 
+def _normalize(name: str) -> str:
+    """Normalize package name for comparison (hyphens vs underscores)."""
+    return name.lower().replace("_", "-")
+
+
 @cache
 def conda_plugin_packages():
     # Both Python 3.12+ and importlib-metadata support ep.dist
-    # but the return type and attributes differ slightly
+    # but the return type and attributes differ slightly.
+    # Normalize names to use hyphens (conda convention) since
+    # importlib.metadata may return underscores (Python convention).
     return set(
-        name
+        _normalize(name)
         for ep in entry_points(group="conda")
         if ep.dist is not None
         and (name := ep.dist.name.strip())
-        and name != "conda-self"
+        and _normalize(name) != "conda-self"
     )
 
 
@@ -28,7 +35,7 @@ def reload_plugin_packages() -> None:
 
 
 def validate_plugin_is_installed(name: str) -> None:
-    if name not in conda_plugin_packages():
+    if _normalize(name) not in conda_plugin_packages():
         raise CondaValueError(
             f"Package '{name}' does not seem to be a valid conda plugin. "
             "Try one of:\n- " + "\n- ".join(sorted(conda_plugin_packages()))

--- a/conda_self/validate.py
+++ b/conda_self/validate.py
@@ -22,6 +22,11 @@ def conda_plugin_packages():
     )
 
 
+def reload_plugin_packages() -> None:
+    """Invalidate the cache to pick up newly installed packages."""
+    conda_plugin_packages.cache_clear()
+
+
 def validate_plugin_is_installed(name: str) -> None:
     if name not in conda_plugin_packages():
         raise CondaValueError(

--- a/conda_self/validate.py
+++ b/conda_self/validate.py
@@ -1,12 +1,7 @@
-import sys
 from functools import cache
+from importlib.metadata import entry_points
 
 from conda.exceptions import CondaValueError
-
-if sys.version_info >= (3, 12):
-    from importlib.metadata import entry_points
-else:
-    from importlib_metadata import entry_points
 
 
 def _normalize(name: str) -> str:
@@ -16,8 +11,6 @@ def _normalize(name: str) -> str:
 
 @cache
 def conda_plugin_packages():
-    # Both Python 3.12+ and importlib-metadata support ep.dist
-    # but the return type and attributes differ slightly.
     # Normalize names to use hyphens (conda convention) since
     # importlib.metadata may return underscores (Python convention).
     return set(

--- a/pixi.lock
+++ b/pixi.lock
@@ -845,7 +845,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
@@ -907,7 +906,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-cpp-0.8.0-h3f2d84a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py310h139afa4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: ./
@@ -935,7 +933,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
@@ -989,7 +986,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-cpp-0.8.0-ha1acc90_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py310hf151d32_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: ./
@@ -1016,7 +1012,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.22.2-h0ea6238_0.conda
@@ -1069,7 +1064,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-cpp-0.8.0-he0c23c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.25.0-py310h1637853_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: ./
@@ -1208,8 +1202,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-cpp-0.8.0-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py310h139afa4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-      - pypi: https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl
       - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/accessible-pygments-0.0.5-pyhd8ed1ab_1.conda
@@ -1329,8 +1321,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-cpp-0.8.0-ha1acc90_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py310hf151d32_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - pypi: https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl
       - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/accessible-pygments-0.0.5-pyhd8ed1ab_1.conda
@@ -1447,8 +1437,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-cpp-0.8.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.25.0-py310h1637853_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - pypi: https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl
       - pypi: ./
   test-py310:
     channels:
@@ -4871,10 +4859,8 @@ packages:
   timestamp: 1751548225624
 - pypi: ./
   name: conda-self
-  version: 0.1.2.dev65+gfab818ff4.d20260408
-  sha256: b09eae5661bcb1cd72747c32ab91e4241aed1ae4dfd878c9fe602bfedbd09694
-  requires_dist:
-  - importlib-metadata>=4.8.3 ; python_full_version < '3.12'
+  version: 0.1.2.dev78+g2a2ba0451.d20260410
+  sha256: 5ca85a78e941ad79db9f6255c9b66f0f3bf2228142ce26f16e2a24bf1871255a
   requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/conda-sphinx-theme-0.4.0-pyhd8ed1ab_1.conda
   sha256: 201154b7b3cb5a7788e6ea7c98f01309e45a318464ae62f6eede38bfaa6ba5de
@@ -5457,29 +5443,6 @@ packages:
   - pkg:pypi/imagesize?source=hash-mapping
   size: 15729
   timestamp: 1773752188889
-- pypi: https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl
-  name: importlib-metadata
-  version: 9.0.0
-  sha256: 2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7
-  requires_dist:
-  - zipp>=3.20
-  - pytest>=6,!=8.1.* ; extra == 'test'
-  - packaging ; extra == 'test'
-  - pyfakefs ; extra == 'test'
-  - pytest-perf>=0.9.2 ; extra == 'test'
-  - sphinx>=3.5 ; extra == 'doc'
-  - jaraco-packaging>=9.3 ; extra == 'doc'
-  - rst-linker>=1.9 ; extra == 'doc'
-  - furo ; extra == 'doc'
-  - sphinx-lint ; extra == 'doc'
-  - jaraco-tidelift>=1.4 ; extra == 'doc'
-  - ipython ; extra == 'perf'
-  - pytest-checkdocs>=2.14 ; extra == 'check'
-  - pytest-ruff>=0.2.1 ; sys_platform != 'cygwin' and extra == 'check'
-  - pytest-cov ; extra == 'cover'
-  - pytest-enabler>=3.4 ; extra == 'enabler'
-  - pytest-mypy>=1.0.1 ; platform_python_implementation != 'PyPy' and extra == 'type'
-  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
   sha256: 82ab2a0d91ca1e7e63ab6a4939356667ef683905dea631bc2121aa534d347b16
   md5: 080594bf4493e6bae2607e65390c520a
@@ -11607,30 +11570,6 @@ packages:
   purls: []
   size: 148572
   timestamp: 1745308037198
-- pypi: https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl
-  name: zipp
-  version: 3.23.0
-  sha256: 071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e
-  requires_dist:
-  - pytest>=6,!=8.1.* ; extra == 'test'
-  - jaraco-itertools ; extra == 'test'
-  - jaraco-functools ; extra == 'test'
-  - more-itertools ; extra == 'test'
-  - big-o ; extra == 'test'
-  - pytest-ignore-flaky ; extra == 'test'
-  - jaraco-test ; extra == 'test'
-  - sphinx>=3.5 ; extra == 'doc'
-  - jaraco-packaging>=9.3 ; extra == 'doc'
-  - rst-linker>=1.9 ; extra == 'doc'
-  - furo ; extra == 'doc'
-  - sphinx-lint ; extra == 'doc'
-  - jaraco-tidelift>=1.4 ; extra == 'doc'
-  - pytest-checkdocs>=2.4 ; extra == 'check'
-  - pytest-ruff>=0.2.1 ; sys_platform != 'cygwin' and extra == 'check'
-  - pytest-cov ; extra == 'cover'
-  - pytest-enabler>=2.2 ; extra == 'enabler'
-  - pytest-mypy ; extra == 'type'
-  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
   sha256: b4533f7d9efc976511a73ef7d4a2473406d7f4c750884be8e8620b0ce70f4dae
   md5: 30cd29cb87d819caead4d55184c1d115

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
 ]
 dependencies = [
   # "conda >=26.1.1",  # not on PyPI, installed via conda
-  "importlib-metadata>=4.8.3; python_version < '3.12'",
 ]
 dynamic = ["version"]
 
@@ -122,11 +121,9 @@ pre-commit = "*"
 
 [tool.pixi.feature.py310.dependencies]
 python = "3.10.*"
-importlib-metadata = ">=4.8.3"
 
 [tool.pixi.feature.py311.dependencies]
 python = "3.11.*"
-importlib-metadata = ">=4.8.3"
 
 [tool.pixi.feature.py312.dependencies]
 python = "3.12.*"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,6 @@ requirements:
   run:
     - python >=3.10
     - conda >=26.1.1
-    - importlib-metadata >=4.8.3  # [py<312]
 
 test:
   requires:

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -10,7 +10,9 @@ def test_help(conda_cli):
 
 
 def test_install_plugin_dry_run(conda_cli):
-    conda_cli("self", "install", "--dry-run", "conda-libmamba-solver", raises=DryRunExit)
+    conda_cli(
+        "self", "install", "--dry-run", "conda-libmamba-solver", raises=DryRunExit
+    )
 
 
 def test_install_plugin_dry_run_not_found(conda_cli):

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -65,7 +65,7 @@ def test_install_not_plugins(
             text=True,
         )
         assert result.returncode != 0
-        assert "SpecsAreNotPlugins" in result.stderr
+        assert "NotPluginError" in result.stderr
         assert not is_installed(prefix, plugin_name)
 
 

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -1,5 +1,5 @@
 import pytest
-from conda.exceptions import CondaValueError, DryRunExit, PackagesNotFoundError
+from conda.exceptions import CondaValueError, DryRunExit
 
 from conda_self.exceptions import SpecsAreNotPlugins
 
@@ -9,38 +9,23 @@ def test_help(conda_cli):
     assert exc.value.code == 0
 
 
-@pytest.mark.parametrize(
-    "plugin_name,ok",
-    (
-        ("conda-libmamba-solver", True),
-        ("conda-fake-solver", False),
-    ),
-)
-def test_install_plugin_dry_run(conda_cli, plugin_name, ok):
-    conda_cli(
-        "self",
-        "install",
-        "--dry-run",
-        plugin_name,
-        raises=DryRunExit if ok else Exception,
-    )
+def test_install_plugin_dry_run(conda_cli):
+    conda_cli("self", "install", "--dry-run", "conda-libmamba-solver", raises=DryRunExit)
 
 
-@pytest.mark.parametrize(
-    "plugin_name,error",
-    (
-        ("idontexist", PackagesNotFoundError),
-        ("flask", SpecsAreNotPlugins),
-        ("numpy", SpecsAreNotPlugins),
-    ),
-)
-def test_install_not_plugins(conda_cli, plugin_name, error):
-    conda_cli(
-        "self",
-        "install",
-        plugin_name,
-        raises=error,
-    )
+def test_install_plugin_dry_run_not_found(conda_cli):
+    _, _, code = conda_cli("self", "install", "--dry-run", "conda-fake-solver")
+    assert code != 0
+
+
+def test_install_package_not_found(conda_cli):
+    _, _, code = conda_cli("self", "install", "idontexist")
+    assert code != 0
+
+
+@pytest.mark.parametrize("plugin_name", ("flask", "numpy"))
+def test_install_not_plugins(conda_cli, plugin_name):
+    conda_cli("self", "install", plugin_name, raises=SpecsAreNotPlugins)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -65,7 +65,7 @@ def test_install_not_plugins(
             text=True,
         )
         assert result.returncode != 0
-        assert "NotPluginError" in result.stderr
+        assert "NotAPluginError" in result.stderr
         assert not is_installed(prefix, plugin_name)
 
 

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -1,32 +1,43 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 from conda.exceptions import CondaValueError, DryRunExit
 
 from conda_self.exceptions import SpecsAreNotPlugins
+from conda_self.testing import conda_cli_subprocess, is_installed
+
+if TYPE_CHECKING:
+    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
+    from pytest import MonkeyPatch
 
 
-def test_help(conda_cli):
+def test_help(conda_cli: CondaCLIFixture):
     out, err, exc = conda_cli("self", "install", "--help", raises=SystemExit)
     assert exc.value.code == 0
 
 
-def test_install_plugin_dry_run(conda_cli):
+def test_install_plugin_dry_run(conda_cli: CondaCLIFixture):
     conda_cli(
         "self", "install", "--dry-run", "conda-libmamba-solver", raises=DryRunExit
     )
 
 
-def test_install_plugin_dry_run_not_found(conda_cli):
-    _, _, code = conda_cli("self", "install", "--dry-run", "conda-fake-solver")
-    assert code != 0
-
-
-def test_install_package_not_found(conda_cli):
-    _, _, code = conda_cli("self", "install", "idontexist")
+@pytest.mark.parametrize(
+    "spec",
+    (
+        pytest.param("conda-fake-solver", id="dry-run-not-found"),
+        pytest.param("idontexist", id="not-found"),
+    ),
+)
+def test_install_not_found(conda_cli: CondaCLIFixture, spec: str):
+    _, _, code = conda_cli("self", "install", spec)
     assert code != 0
 
 
 @pytest.mark.parametrize("plugin_name", ("flask", "numpy"))
-def test_install_not_plugins(conda_cli, plugin_name):
+def test_install_not_plugins(conda_cli: CondaCLIFixture, plugin_name: str):
     conda_cli("self", "install", plugin_name, raises=SpecsAreNotPlugins)
 
 
@@ -37,5 +48,25 @@ def test_install_not_plugins(conda_cli, plugin_name):
         "defaults::conda-libmamba-solver",
     ),
 )
-def test_install_channel_in_spec_rejected(conda_cli, spec):
+def test_install_channel_in_spec_rejected(conda_cli: CondaCLIFixture, spec: str):
     conda_cli("self", "install", spec, raises=CondaValueError)
+
+
+def test_install_plugin(
+    monkeypatch: MonkeyPatch,
+    tmp_env: TmpEnvFixture,
+    conda_channel: str,
+    python_version: str,
+):
+    monkeypatch.setenv("CONDA_CHANNELS", conda_channel)
+
+    with tmp_env("conda", "conda-self", f"python={python_version}") as prefix:
+        assert not is_installed(prefix, "conda-index")
+        conda_cli_subprocess(
+            prefix,
+            "self",
+            "install",
+            "--yes",
+            "conda-index",
+        )
+        assert is_installed(prefix, "conda-index")

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 import pytest
 from conda.exceptions import CondaValueError, DryRunExit
 
-from conda_self.exceptions import SpecsAreNotPlugins
 from conda_self.testing import conda_cli_subprocess, is_installed
 
 if TYPE_CHECKING:
@@ -37,8 +36,29 @@ def test_install_not_found(conda_cli: CondaCLIFixture, spec: str):
 
 
 @pytest.mark.parametrize("plugin_name", ("flask", "numpy"))
-def test_install_not_plugins(conda_cli: CondaCLIFixture, plugin_name: str):
-    conda_cli("self", "install", plugin_name, raises=SpecsAreNotPlugins)
+def test_install_not_plugins(
+    plugin_name: str,
+    monkeypatch: MonkeyPatch,
+    tmp_env: TmpEnvFixture,
+    conda_channel: str,
+    python_version: str,
+):
+    monkeypatch.setenv("CONDA_CHANNELS", conda_channel)
+
+    with tmp_env("conda", "conda-self", f"python={python_version}") as prefix:
+        result = conda_cli_subprocess(
+            prefix,
+            "self",
+            "install",
+            "--yes",
+            plugin_name,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "not" in result.stderr.lower() and "plugin" in result.stderr.lower()
+        assert not is_installed(prefix, plugin_name)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
 import pytest
@@ -46,6 +47,13 @@ def test_install_not_plugins(
     monkeypatch.setenv("CONDA_CHANNELS", conda_channel)
 
     with tmp_env("conda", "conda-self", f"python={python_version}") as prefix:
+        # Verify the subprocess targets this prefix (install.py uses sys.prefix)
+        result = conda_cli_subprocess(
+            prefix, "info", "--json", capture_output=True, text=True
+        )
+        info = json.loads(result.stdout)
+        assert info["sys.prefix"] == str(prefix)
+
         result = conda_cli_subprocess(
             prefix,
             "self",
@@ -57,7 +65,7 @@ def test_install_not_plugins(
             text=True,
         )
         assert result.returncode != 0
-        assert "not" in result.stderr.lower() and "plugin" in result.stderr.lower()
+        assert "SpecsAreNotPlugins" in result.stderr
         assert not is_installed(prefix, plugin_name)
 
 

--- a/tests/test_cli_remove.py
+++ b/tests/test_cli_remove.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from conda_self.exceptions import SpecsCanNotBeRemoved
+from conda_self.exceptions import PluginRemoveError
 from conda_self.testing import conda_cli_subprocess, is_installed
 
 if TYPE_CHECKING:
@@ -20,9 +20,9 @@ def test_help(conda_cli):
 @pytest.mark.parametrize(
     "spec,error",
     (
-        ("conda", SpecsCanNotBeRemoved),
-        ("conda-libmamba-solver", SpecsCanNotBeRemoved),
-        ("python", SpecsCanNotBeRemoved),
+        ("conda", PluginRemoveError),
+        ("conda-libmamba-solver", PluginRemoveError),
+        ("python", PluginRemoveError),
     ),
 )
 def test_remove_protected_plugin(conda_cli, spec, error):

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -3,19 +3,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-from conda import __version__ as conda_version
-from conda.exceptions import CondaValueError, DryRunExit
-from conda.models.channel import Channel
-from conda.models.records import PackageRecord
-from conda_libmamba_solver import __version__ as clms_version
+from conda.exceptions import CondaValueError
 
-from conda_self import query, validate
+from conda_self.testing import conda_cli_subprocess
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
-
-    from conda.testing.fixtures import CondaCLIFixture
-    from pytest_mock import MockerFixture
+    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
+    from pytest import MonkeyPatch
 
 
 def test_help(conda_cli: CondaCLIFixture):
@@ -23,136 +17,49 @@ def test_help(conda_cli: CondaCLIFixture):
     assert exc.value.code == 0
 
 
-@pytest.mark.parametrize(
-    "latest_version,message",
-    (
-        pytest.param(
-            "1",
-            "conda is already using the latest version available!",
-            id="Outdated",
-        ),
-        pytest.param(
-            conda_version,
-            "conda is already using the latest version available!",
-            id="Same",
-        ),
-        pytest.param(
-            "2040",
-            "Latest conda: 2040",
-            id="Updatable",
-        ),
-    ),
-)
-def test_update_conda(
-    conda_cli: CondaCLIFixture, mocker: MockerFixture, latest_version: str, message: str
-):
-    mocker.patch.object(
-        query,
-        "latest",
-        return_value=PackageRecord(
-            name="conda",
-            version=latest_version,
-            build="0",
-            build_number=0,
-            channel=Channel("conda-forge"),
-        ),
-    )
-    out, err, exc = conda_cli("self", "update", "--dry-run", raises=DryRunExit)
-    assert f"Installed conda: {conda_version}" in out
-    assert message in out
-
-
-@pytest.mark.parametrize(
-    "plugin_name,ok", (("conda-libmamba-solver", True), ("conda-fake-solver", False))
-)
-def test_update_plugin(
-    conda_cli: CondaCLIFixture, plugin_name: str, ok: tuple[str, bool]
-):
+def test_update_plugin_invalid(conda_cli: CondaCLIFixture):
     conda_cli(
-        "self",
-        "update",
-        "--dry-run",
-        "--plugin",
-        plugin_name,
-        raises=DryRunExit if ok else CondaValueError,
+        "self", "update", "--plugin", "conda-fake-solver", raises=CondaValueError
     )
 
 
 @pytest.mark.parametrize(
-    "latest_versions,message_parts",
+    "extra_args,expected",
     (
+        pytest.param((), "conda (installed:", id="conda"),
         pytest.param(
-            {
-                "conda": conda_version,
-                "conda-libmamba-solver": clms_version,
-            },
-            (
-                (
-                    "conda is using the latest version "
-                    "available, but may have outdated dependencies."
-                ),
-                (
-                    "conda-libmamba-solver is using the latest version "
-                    "available, but may have outdated dependencies."
-                ),
-            ),
-            id="No updates",
+            ("--plugin", "conda-libmamba-solver"),
+            "conda-libmamba-solver (installed:",
+            id="plugin",
         ),
+        pytest.param(("--all",), "conda (installed:", id="all"),
         pytest.param(
-            {
-                "conda": conda_version,
-                "conda-libmamba-solver": "2080",
-            },
-            (
-                (
-                    "conda is using the latest version "
-                    "available, but may have outdated dependencies."
-                ),
-                "Latest conda-libmamba-solver: 2080",
-            ),
-            id="Update one",
-        ),
-        pytest.param(
-            {
-                "conda": "2040",
-                "conda-libmamba-solver": "2080",
-            },
-            (
-                "Latest conda: 2040",
-                "Latest conda-libmamba-solver: 2080",
-            ),
-            id="Update all",
+            ("--all", "--force-reinstall"),
+            "conda (installed:",
+            id="all+force-reinstall",
         ),
     ),
 )
-def test_update_all(
-    conda_cli: CondaCLIFixture,
-    mocker: MockerFixture,
-    latest_versions: dict[str, str],
-    message_parts: tuple[str, ...],
+def test_update(
+    extra_args: tuple[str, ...],
+    expected: str,
+    monkeypatch: MonkeyPatch,
+    tmp_env: TmpEnvFixture,
+    conda_channel: str,
+    python_version: str,
 ):
-    def mock_latest(package_name: str, _: str, __: Iterable[str]) -> PackageRecord:
-        return PackageRecord(
-            name=package_name,
-            version=latest_versions.get(package_name),
-            build="0",
-            build_number=0,
-            channel=Channel("conda-forge"),
-        )
+    monkeypatch.setenv("CONDA_CHANNELS", conda_channel)
 
-    mocker.patch.object(
-        validate, "conda_plugin_packages", return_value=["conda-libmamba-solver"]
-    )
-    mocker.patch.object(query, "latest", mock_latest)
-    out, _, _ = conda_cli(
-        "self",
-        "update",
-        "--all",
-        "--dry-run",
-        raises=DryRunExit,
-    )
-    # Check that installed versions are reported (exact version may differ in canary)
-    assert "Installed conda:" in out
-    assert "Installed conda-libmamba-solver:" in out
-    for message in message_parts:
-        assert message in out
+    with tmp_env("conda", "conda-self", f"python={python_version}") as prefix:
+        result = conda_cli_subprocess(
+            prefix,
+            "self",
+            "update",
+            *extra_args,
+            "--dry-run",
+            "--yes",
+            capture_output=True,
+            text=True,
+        )
+        assert "Updating" in result.stdout
+        assert expected in result.stdout

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -18,9 +18,7 @@ def test_help(conda_cli: CondaCLIFixture):
 
 
 def test_update_plugin_invalid(conda_cli: CondaCLIFixture):
-    conda_cli(
-        "self", "update", "--plugin", "conda-fake-solver", raises=CondaValueError
-    )
+    conda_cli("self", "update", "--plugin", "conda-fake-solver", raises=CondaValueError)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes inconsistencies in how `conda self` commands interact with conda.

### `conda self install` (fixes #15)

Was using `conda.api.Solver` + `UnlinkLinkTransaction.execute()` in-process. The frozen env check (`protect_frozen_envs`) only lives in `conda/cli/install.py::validate_install_command()`, so `conda self install` silently ignored base protection set up by `conda doctor --fix`, while `remove` and `update` already correctly handled it via subprocess.

Switches `conda self install` to subprocess (matching `remove` and `update`):

- Installs go through subprocess with `--override-frozen`
- Post-install plugin validation: clear the `@cache` on `conda_plugin_packages`, re-read `entry_points()`, uninstall and raise `SpecsAreNotPlugins` if any installed package has no `conda` entry point group
- Dry-run passes `--dry-run` to the subprocess, then raises `DryRunExit()`
- Inline channel specs (`channel::pkg`) are explicitly rejected with `CondaValueError`

### `conda self update` (fixes #85)

Was manually querying repodata to find the highest version number, then pinning it for `conda install`. This bypassed the solver's compatibility checks, causing failures when the latest version doesn't support the current Python (e.g. 3.9 after conda-forge dropped it).

Drops the manual repodata query and version pinning. Passes unpinned package names to `conda install --update-specs` and lets the solver find the latest compatible version.

### Unified channel handling

Both `install` and `update` now use configured channels (no `--override-channels`). The previous update path forced all specs to resolve against a single channel from the first installed package, which broke `--all` when packages came from different channels. This matches how `conda update` normally works.

## Changes

- `install.py`: Single `install_specs_in_protected_env` function with no channel parameter, used by both `install` and `update`
- `main_install.py`: Subprocess-based install with post-install plugin validation
- `main_update.py`: Drop `check_updates`/`latest` loop and channel pinning, get installed versions from `PrefixData` for display only
- `query.py`: Remove `check_updates()` and `latest()` (no longer needed)
- `test_cli_install.py`: Integration test with real install in `tmp_env`, consolidated parametrized tests, no mocks
- `test_cli_update.py`: Integration tests with `tmp_env`

## Test plan

- `test_install_plugin_dry_run` -- DryRunExit for valid package
- `test_install_not_found` -- non-zero return for non-existent specs (parametrized)
- `test_install_not_plugins` -- SpecsAreNotPlugins for flask/numpy
- `test_install_channel_in_spec_rejected` -- CondaValueError for channel::pkg specs
- `test_install_plugin` -- real install of conda-index in isolated tmp_env
- `test_update` -- integration tests with tmp_env (parametrized: conda, plugin, all, all+force-reinstall)
- `test_update_plugin_invalid` -- CondaValueError for non-existent plugin