### PR TITLE
Fix test_install_plugin_dry_run missing channel configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,10 +60,8 @@ jobs:
           environments: test-py${{ matrix.python-version }}
       - name: Ensure package is installed
         run: pixi reinstall --environment test-py${{ matrix.python-version }} conda-self
-      - name: Setup project
-        run: |
-          echo "channels: [${{ matrix.channel }}]" > .pixi/envs/test-py${{ matrix.python-version }}/.condarc
-          pixi run --environment test-py${{ matrix.python-version }} python -m conda info
+      - name: Show conda info
+        run: pixi run --environment test-py${{ matrix.python-version }} python -m conda info
       - name: Run tests
         env:
           TEST_CONDA_CHANNEL: ${{ matrix.channel }}

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -18,7 +18,12 @@ def test_help(conda_cli: CondaCLIFixture):
     assert exc.value.code == 0
 
 
-def test_install_plugin_dry_run(conda_cli: CondaCLIFixture):
+def test_install_plugin_dry_run(
+    conda_cli: CondaCLIFixture,
+    monkeypatch: MonkeyPatch,
+    conda_channel: str,
+):
+    monkeypatch.setenv("CONDA_CHANNELS", conda_channel)
     conda_cli(
         "self", "install", "--dry-run", "conda-libmamba-solver", raises=DryRunExit
     )


### PR DESCRIPTION
## Summary

`test_install_plugin_dry_run` fails locally because `conda self install` runs a subprocess that needs channels configured. CI provides this via `.condarc` created by the test workflow, but local pixi environments don't have it, causing `NoChannelsConfiguredError`.

Adds `CONDA_CHANNELS` via `monkeypatch.setenv`, matching the pattern used by all other subprocess-based install tests.

## Test plan

- [x] `test_install_plugin_dry_run` passes locally without `.condarc`
- [x] Pre-commit clean