### PR TITLE
Fix missing context import in query.py

### DIFF
--- a/conda_self/query.py
+++ b/conda_self/query.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 from contextlib import suppress
 
+from conda.base.context import context
 from conda.core.prefix_data import PrefixData
 from conda.models.prefix_graph import PrefixGraph
 


### PR DESCRIPTION
## Summary

Fixes the pre-commit failure on main introduced by #116.

The PR branch was based on an older `query.py` that already had `from conda.base.context import context` (needed by `check_updates`/`latest`). Between the merge base and main, those functions were moved elsewhere, removing the import. The PR's diff only touched the `protect` line, so the squash merge applied cleanly against main's slimmed-down `query.py` without a conflict, but silently dropped the import the new code depends on.

## Changes

- Add `from conda.base.context import context` to `conda_self/query.py`

## Test plan

- `pre-commit run --all-files` passes (ruff F821, mypy `name-defined`)