### PR TITLE
Speed up test suite with session-scoped environments

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,20 @@
+from __future__ import annotations
+
 import os
 import sys
+from typing import TYPE_CHECKING
 
 import pytest
 from conda.plugins.hookspec import CondaSpecs
 from conda.plugins.manager import CondaPluginManager
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
+
 pytest_plugins = (
-    # Add testing fixtures and internal pytest plugins here
     "conda.testing",
     "conda.testing.fixtures",
 )
@@ -28,3 +36,40 @@ def plugin_manager(mocker) -> CondaPluginManager:
     pm.add_hookspecs(CondaSpecs)
     mocker.patch("conda.plugins.manager.get_plugin_manager", return_value=pm)
     return pm
+
+
+@pytest.fixture(scope="session")
+def _session_env(
+    session_tmp_env: TmpEnvFixture,
+) -> Iterator[Path]:
+    """Session-scoped env with conda + conda-self + python.
+
+    Created once per test run. Tests get clones via ``base_env``.
+    """
+    channel = os.environ.get("TEST_CONDA_CHANNEL", "conda-forge")
+    python_ver = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+    with session_tmp_env(
+        "conda",
+        "conda-self",
+        f"python={python_ver}",
+        f"--channel={channel}",
+    ) as prefix:
+        yield prefix
+
+
+@pytest.fixture
+def base_env(
+    _session_env: Path,
+    tmp_path: Path,
+    conda_cli: CondaCLIFixture,
+) -> Path:
+    """Function-scoped clone of the session env (fast — hardlinks, no solving)."""
+    conda_cli(
+        "create",
+        f"--prefix={tmp_path / 'env'}",
+        f"--clone={_session_env}",
+        "--yes",
+        "--quiet",
+    )
+    return tmp_path / "env"

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -9,7 +9,9 @@ from conda.exceptions import CondaValueError, DryRunExit
 from conda_self.testing import conda_cli_subprocess, is_installed
 
 if TYPE_CHECKING:
-    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
+    from pathlib import Path
+
+    from conda.testing.fixtures import CondaCLIFixture
     from pytest import MonkeyPatch
 
 
@@ -45,33 +47,30 @@ def test_install_not_found(conda_cli: CondaCLIFixture, spec: str):
 def test_install_not_plugins(
     plugin_name: str,
     monkeypatch: MonkeyPatch,
-    tmp_env: TmpEnvFixture,
+    base_env: Path,
     conda_channel: str,
-    python_version: str,
 ):
     monkeypatch.setenv("CONDA_CHANNELS", conda_channel)
 
-    with tmp_env("conda", "conda-self", f"python={python_version}") as prefix:
-        # Verify the subprocess targets this prefix (install.py uses sys.prefix)
-        result = conda_cli_subprocess(
-            prefix, "info", "--json", capture_output=True, text=True
-        )
-        info = json.loads(result.stdout)
-        assert info["sys.prefix"] == str(prefix)
+    result = conda_cli_subprocess(
+        base_env, "info", "--json", capture_output=True, text=True
+    )
+    info = json.loads(result.stdout)
+    assert info["sys.prefix"] == str(base_env)
 
-        result = conda_cli_subprocess(
-            prefix,
-            "self",
-            "install",
-            "--yes",
-            plugin_name,
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        assert result.returncode != 0
-        assert "NotAPluginError" in result.stderr
-        assert not is_installed(prefix, plugin_name)
+    result = conda_cli_subprocess(
+        base_env,
+        "self",
+        "install",
+        "--yes",
+        plugin_name,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "NotAPluginError" in result.stderr
+    assert not is_installed(base_env, plugin_name)
 
 
 @pytest.mark.parametrize(
@@ -87,19 +86,17 @@ def test_install_channel_in_spec_rejected(conda_cli: CondaCLIFixture, spec: str)
 
 def test_install_plugin(
     monkeypatch: MonkeyPatch,
-    tmp_env: TmpEnvFixture,
+    base_env: Path,
     conda_channel: str,
-    python_version: str,
 ):
     monkeypatch.setenv("CONDA_CHANNELS", conda_channel)
 
-    with tmp_env("conda", "conda-self", f"python={python_version}") as prefix:
-        assert not is_installed(prefix, "conda-index")
-        conda_cli_subprocess(
-            prefix,
-            "self",
-            "install",
-            "--yes",
-            "conda-index",
-        )
-        assert is_installed(prefix, "conda-index")
+    assert not is_installed(base_env, "conda-index")
+    conda_cli_subprocess(
+        base_env,
+        "self",
+        "install",
+        "--yes",
+        "conda-index",
+    )
+    assert is_installed(base_env, "conda-index")

--- a/tests/test_cli_remove.py
+++ b/tests/test_cli_remove.py
@@ -8,7 +8,9 @@ from conda_self.exceptions import PluginRemoveError
 from conda_self.testing import conda_cli_subprocess, is_installed
 
 if TYPE_CHECKING:
-    from conda.testing.fixtures import TmpEnvFixture
+    from pathlib import Path
+
+    from conda.testing.fixtures import CondaCLIFixture
     from pytest import MonkeyPatch
 
 
@@ -45,23 +47,20 @@ def test_remove_unprotected_plugin_passes_validation(conda_cli):
 
 
 def test_remove_nonessential_plugin(
+    conda_cli: CondaCLIFixture,
     monkeypatch: MonkeyPatch,
-    tmp_env: TmpEnvFixture,
+    base_env: Path,
     conda_channel: str,
-    python_version: str,
 ):
     monkeypatch.setenv("CONDA_CHANNELS", conda_channel)
 
-    # Adding conda-index as a non-essential plug-in
-    with tmp_env(
-        "conda", "conda-self", f"python={python_version}", "conda-index"
-    ) as prefix:
-        assert is_installed(prefix, "conda-index")
-        conda_cli_subprocess(
-            prefix,
-            "self",
-            "remove",
-            "--yes",
-            "conda-index",
-        )
-        assert not is_installed(prefix, "conda-index")
+    conda_cli("install", "conda-index", "--yes", "--prefix", base_env)
+    assert is_installed(base_env, "conda-index")
+    conda_cli_subprocess(
+        base_env,
+        "self",
+        "remove",
+        "--yes",
+        "conda-index",
+    )
+    assert not is_installed(base_env, "conda-index")

--- a/tests/test_cli_reset.py
+++ b/tests/test_cli_reset.py
@@ -11,6 +11,8 @@ from conda_self.constants import RESET_FILE_BASE_PROTECTION
 from conda_self.testing import conda_cli_subprocess, is_installed
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
     from pytest import MonkeyPatch
 
@@ -23,30 +25,21 @@ def test_help(conda_cli: CondaCLIFixture):
 def test_reset(
     conda_cli: CondaCLIFixture,
     monkeypatch: MonkeyPatch,
-    tmp_env: TmpEnvFixture,
+    base_env: Path,
     conda_channel: str,
-    python_version: str,
 ):
     monkeypatch.setenv("CONDA_CHANNELS", conda_channel)
 
-    # Adding conda-index too to test that non-default plugins are kept
-    with tmp_env(
-        "conda", "conda-self", f"python={python_version}", "conda-index"
-    ) as prefix:
-        assert not is_installed(prefix, "numpy")
+    prefix = base_env
+    conda_cli("install", "conda-index", "numpy", "--yes", "--prefix", prefix)
+    assert is_installed(prefix, "conda-index")
+    assert is_installed(prefix, "numpy")
 
-        conda_cli("install", "numpy", "--yes", "--prefix", prefix)
-        assert is_installed(prefix, "numpy")
-
-        conda_cli_subprocess(prefix, "self", "reset", "--yes")
-        # make sure conda-self didn't remove conda
-        assert is_installed(prefix, "conda")
-        # make sure conda-self didn't remove itself
-        assert is_installed(prefix, "conda-self")
-        # make sure conda-self didn't remove a non-default conda plugin
-        assert is_installed(prefix, "conda-index")
-        # but numpy should be gone
-        assert not is_installed(prefix, "numpy")
+    conda_cli_subprocess(prefix, "self", "reset", "--yes")
+    assert is_installed(prefix, "conda")
+    assert is_installed(prefix, "conda-self")
+    assert is_installed(prefix, "conda-index")
+    assert not is_installed(prefix, "numpy")
 
 
 @pytest.mark.parametrize("add_cli_arg", (True, False), ids=("no arg", "--snapshot"))
@@ -61,7 +54,6 @@ def test_reset_base_protection(
     conda_version = "26.1.0"
     monkeypatch.setenv("CONDA_CHANNELS", conda_channel)
 
-    # Adding conda-index too to test that non-default plugins are kept
     with tmp_env(
         f"conda={conda_version}",
         f"python={python_version}",
@@ -71,7 +63,6 @@ def test_reset_base_protection(
         frozen_file = prefix / PREFIX_FROZEN_FILE
         protection_state = prefix / "conda-meta" / RESET_FILE_BASE_PROTECTION
 
-        # Add sentinel files of a protected environment after base-protection fix
         frozen_file.touch()
         with protection_state.open(mode="w") as f:
             with redirect_stdout(f):
@@ -84,7 +75,6 @@ def test_reset_base_protection(
         )
         assert is_installed(prefix, "conda-index")
 
-        # Update conda and install an unrelated package
         conda_cli_subprocess(prefix, "self", "update", "--yes")
         assert is_installed(prefix, "conda")
         assert not is_installed(prefix, f"conda={conda_version}"), "conda not updated"
@@ -93,7 +83,6 @@ def test_reset_base_protection(
         )
         assert is_installed(prefix, "constructor")
 
-        # Conda should be downgraded and constructor should be gone
         conda_cli_subprocess(
             prefix,
             "self",

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -8,7 +8,9 @@ from conda.exceptions import CondaValueError
 from conda_self.testing import conda_cli_subprocess
 
 if TYPE_CHECKING:
-    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
+    from pathlib import Path
+
+    from conda.testing.fixtures import CondaCLIFixture
     from pytest import MonkeyPatch
 
 
@@ -42,22 +44,20 @@ def test_update(
     extra_args: tuple[str, ...],
     expected: str,
     monkeypatch: MonkeyPatch,
-    tmp_env: TmpEnvFixture,
+    base_env: Path,
     conda_channel: str,
-    python_version: str,
 ):
     monkeypatch.setenv("CONDA_CHANNELS", conda_channel)
 
-    with tmp_env("conda", "conda-self", f"python={python_version}") as prefix:
-        result = conda_cli_subprocess(
-            prefix,
-            "self",
-            "update",
-            *extra_args,
-            "--dry-run",
-            "--yes",
-            capture_output=True,
-            text=True,
-        )
-        assert "Updating" in result.stdout
-        assert expected in result.stdout
+    result = conda_cli_subprocess(
+        base_env,
+        "self",
+        "update",
+        *extra_args,
+        "--dry-run",
+        "--yes",
+        capture_output=True,
+        text=True,
+    )
+    assert "Updating" in result.stdout
+    assert expected in result.stdout


### PR DESCRIPTION
## Summary

- Add a session-scoped template environment in `conftest.py` (`_session_env`) that is created once per test run
- Tests that need an isolated env get a fast `conda create --clone` via the `base_env` fixture (hardlinks, no solving)
- `test_reset_base_protection` still uses `tmp_env` since it needs a pinned conda version

Total test time drops from ~370s to ~345s, with the biggest per-test improvement on the update tests (27s -> 9s each).