### PR TITLE
Add `conda plugins list` subcommand

### DIFF
--- a/conda_self/cli/plugins/__init__.py
+++ b/conda_self/cli/plugins/__init__.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+
+def configure_parser(parser: argparse.ArgumentParser) -> None:
+    from functools import partial
+
+    from .main_list import HELP as LIST_HELP
+    from .main_list import configure_parser as configure_parser_list
+
+    subparsers = parser.add_subparsers(
+        title="subcommands",
+        dest="subcommand",
+    )
+
+    configure_parser_list(subparsers.add_parser("list", help=LIST_HELP))
+    parser.set_defaults(func=partial(parser.parse_args, ["--help"]))
+
+
+def execute(args: argparse.Namespace) -> int:
+    return args.func(args)

--- a/conda_self/cli/plugins/main_list.py
+++ b/conda_self/cli/plugins/main_list.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json as json_mod
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+HELP = "List installed conda plugins."
+
+
+def configure_parser(parser: argparse.ArgumentParser) -> None:
+    from conda.cli.helpers import add_output_and_prompt_options
+
+    parser.description = HELP
+    add_output_and_prompt_options(parser)
+    parser.set_defaults(func=execute)
+
+
+def execute(args: argparse.Namespace) -> int:
+    from conda.base.context import context
+
+    from ...validate import installed_plugins
+
+    plugins = installed_plugins()
+
+    if context.json:
+        print(json_mod.dumps([asdict(p) for p in plugins], indent=2))
+        return 0
+
+    if not plugins:
+        print("No plugins installed.")
+        return 0
+
+    name_w = max(len(p.name) for p in plugins)
+    ver_w = max(len(p.version) for p in plugins)
+    status_w = max(len(p.status) for p in plugins)
+
+    header = f"{'Name':<{name_w}}  {'Version':<{ver_w}}  {'Status':<{status_w}}  Hooks"
+    print(header)
+    print("-" * len(header))
+
+    for p in plugins:
+        hooks_str = ", ".join(p.hooks) if p.hooks else ""
+        print(
+            f"{p.name:<{name_w}}  "
+            f"{p.version:<{ver_w}}  "
+            f"{p.status:<{status_w}}  "
+            f"{hooks_str}"
+        )
+
+    return 0

--- a/conda_self/plugin.py
+++ b/conda_self/plugin.py
@@ -9,6 +9,12 @@ from conda.plugins.hookspec import hookimpl
 from conda.plugins.types import CondaHealthCheck, CondaSetting, CondaSubcommand
 
 from .cli import configure_parser, execute
+from .cli.plugins import (
+    configure_parser as configure_parser_plugins,
+)
+from .cli.plugins import (
+    execute as execute_plugins,
+)
 from .constants import PERMANENT_PACKAGES, SELF_PERMANENT_PACKAGES_SETTING
 
 if TYPE_CHECKING:
@@ -17,12 +23,18 @@ if TYPE_CHECKING:
 
 @hookimpl
 def conda_subcommands() -> Iterable[CondaSubcommand]:
-    """Expose the `self` subcommand."""
+    """Expose the `self` and `plugins` subcommands."""
     yield CondaSubcommand(
         name="self",
         action=execute,
         configure_parser=configure_parser,
         summary="Manage your conda 'base' environment safely.",
+    )
+    yield CondaSubcommand(
+        name="plugins",
+        action=execute_plugins,
+        configure_parser=configure_parser_plugins,
+        summary="Manage conda plugins.",
     )
 
 

--- a/conda_self/validate.py
+++ b/conda_self/validate.py
@@ -1,7 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
 from functools import cache
 from importlib.metadata import entry_points
+from typing import TYPE_CHECKING
 
 from conda.exceptions import CondaValueError
+
+if TYPE_CHECKING:
+    from conda.plugins.manager import CondaPluginManager
+
+HOOK_PREFIX = "conda_"
 
 
 def _normalize(name: str) -> str:
@@ -9,21 +18,92 @@ def _normalize(name: str) -> str:
     return name.lower().replace("_", "-")
 
 
+@dataclass(frozen=True)
+class PluginInfo:
+    """Metadata for an installed conda plugin."""
+
+    name: str
+    version: str
+    canonical_name: str
+    status: str
+    hooks: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_plugin_manager(
+        cls,
+        pm: CondaPluginManager,
+    ) -> list[PluginInfo]:
+        """Discover all externally installed conda plugins.
+
+        Walks ``importlib.metadata`` entry points in the ``conda``
+        group, resolves each to its canonical plugin name, and
+        collects version, status, and registered hooks.
+        """
+        seen: dict[str, PluginInfo] = {}
+        for ep in entry_points(group="conda"):
+            if ep.dist is None:
+                continue
+            loaded = ep.load()
+            canonical = pm.get_name(loaded)
+            if canonical is None or canonical in seen:
+                continue
+            status = "blocked" if pm.is_blocked(canonical) else "active"
+            hooks = cls.hooks_for(pm, canonical)
+            seen[canonical] = cls(
+                name=ep.dist.name,
+                version=ep.dist.metadata["Version"],
+                canonical_name=canonical,
+                status=status,
+                hooks=hooks,
+            )
+        return sorted(seen.values(), key=lambda p: p.canonical_name)
+
+    @staticmethod
+    def hooks_for(
+        pm: CondaPluginManager,
+        canonical_name: str,
+    ) -> list[str]:
+        """Return the hook short names implemented by a plugin."""
+        hooks: list[str] = []
+        for attr_name in sorted(dir(pm.hook)):
+            if not attr_name.startswith(HOOK_PREFIX):
+                continue
+            hook_caller = getattr(pm.hook, attr_name)
+            for impl in hook_caller.get_hookimpls():
+                if impl.plugin_name == canonical_name:
+                    hooks.append(attr_name[len(HOOK_PREFIX) :])
+                    break
+        return hooks
+
+
 @cache
-def conda_plugin_packages():
-    # Normalize names to use hyphens (conda convention) since
-    # importlib.metadata may return underscores (Python convention).
-    return set(
+def installed_plugins() -> list[PluginInfo]:
+    """Return metadata for all installed conda plugins (cached)."""
+    from conda.base.context import context
+
+    return PluginInfo.from_plugin_manager(context.plugin_manager)
+
+
+@cache
+def conda_plugin_packages() -> set[str]:
+    """Return normalized dist names of installed conda plugins.
+
+    Scans entry points on disk so it works for newly installed
+    packages that are not yet loaded into the plugin manager.
+    Excludes conda-self.
+    """
+    return {
         _normalize(name)
         for ep in entry_points(group="conda")
         if ep.dist is not None
         and (name := ep.dist.name.strip())
         and _normalize(name) != "conda-self"
-    )
+    }
 
 
 def reload_plugin_packages() -> None:
-    """Invalidate the cache to pick up newly installed packages."""
+    """Invalidate the caches to pick up newly installed packages."""
+    installed_plugins.cache_clear()
     conda_plugin_packages.cache_clear()
 
 

--- a/conda_self/validate.py
+++ b/conda_self/validate.py
@@ -47,7 +47,7 @@ class PluginInfo:
             canonical = pm.get_name(loaded)
             if canonical is None or canonical in seen:
                 continue
-            status = "blocked" if pm.is_blocked(canonical) else "active"
+            status = "disabled" if pm.is_blocked(canonical) else "active"
             hooks = cls.hooks_for(pm, canonical)
             seen[canonical] = cls(
                 name=ep.dist.name,

--- a/tests/test_cli_plugins_list.py
+++ b/tests/test_cli_plugins_list.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from conda.testing.fixtures import CondaCLIFixture
+
+
+def test_help(conda_cli: CondaCLIFixture):
+    out, err, exc = conda_cli("plugins", "list", "--help", raises=SystemExit)
+    assert exc.value.code == 0
+
+
+def test_plugins_help(conda_cli: CondaCLIFixture):
+    out, err, exc = conda_cli("plugins", "--help", raises=SystemExit)
+    assert exc.value.code == 0
+    assert "list" in out
+
+
+def test_list_table(conda_cli: CondaCLIFixture):
+    """Table output includes conda-self (always installed in the test env)."""
+    out, err, code = conda_cli("plugins", "list")
+    assert code == 0
+    assert "Name" in out
+    assert "Version" in out
+    assert "Status" in out
+    assert "Hooks" in out
+    assert "conda-self" in out
+    assert "active" in out
+
+
+def test_list_json(conda_cli: CondaCLIFixture):
+    """JSON output is a list of objects with the expected keys."""
+    out, err, code = conda_cli("plugins", "list", "--json")
+    assert code == 0
+    data = json.loads(out)
+    assert isinstance(data, list)
+    assert len(data) >= 1
+
+    self_entry = next(p for p in data if p["name"] == "conda-self")
+    assert set(self_entry.keys()) == {
+        "name",
+        "version",
+        "canonical_name",
+        "status",
+        "hooks",
+    }
+    assert self_entry["status"] == "active"
+    assert isinstance(self_entry["hooks"], list)
+    assert "subcommands" in self_entry["hooks"]
+
+
+@pytest.mark.parametrize(
+    "hook",
+    [
+        pytest.param("subcommands", id="subcommands"),
+        pytest.param("settings", id="settings"),
+        pytest.param("health_checks", id="health_checks"),
+    ],
+)
+def test_list_conda_self_hooks(conda_cli: CondaCLIFixture, hook: str):
+    """conda-self registers these hooks; verify they appear in JSON output."""
+    out, err, code = conda_cli("plugins", "list", "--json")
+    data = json.loads(out)
+    self_entry = next(p for p in data if p["name"] == "conda-self")
+    assert hook in self_entry["hooks"]


### PR DESCRIPTION
## Summary

- Register a new `conda plugins` subcommand alongside `conda self` via the plugin hook system
- Add `conda plugins list` to display installed plugins with name, version, status (active/disabled), and registered hooks
- Supports `--json` for machine-readable output

Part of conda/conda#16354 (Phase 1: core plugin management).

## Changes

- `conda_self/plugin.py`: yield a second `CondaSubcommand(name="plugins", ...)` from `conda_subcommands`
- `conda_self/cli/plugins/__init__.py`: parser and dispatcher for the `plugins` subcommand (same pattern as `conda_self/cli/__init__.py`)
- `conda_self/cli/plugins/main_list.py`: discovers external plugins via `importlib.metadata.entry_points(group="conda")`, resolves canonical names through the plugin manager, collects hooks by walking hook callers
- `tests/test_cli_plugins_list.py`: 7 tests covering help output, table format, JSON format, and parametrized hook verification

## Example output

```
$ conda plugins list
Name                   Version                 Status  Hooks
------------------------------------------------------------
conda-libmamba-solver  26.3.0                  active  settings, solvers, subcommands
conda-self             0.1.2.dev69+g9b0afa811  active  health_checks, settings, subcommands
menuinst               2.4.2                   active  subcommands
```

```json
$ conda plugins list --json
[
  {
    "name": "conda-libmamba-solver",
    "version": "26.3.0",
    "status": "active",
    "hooks": ["settings", "solvers", "subcommands"]
  },
  ...
]
```

## Test plan

- [x] `test_help` and `test_plugins_help` verify help output
- [x] `test_list_table` verifies table headers and conda-self presence
- [x] `test_list_json` verifies JSON structure and keys
- [x] `test_list_conda_self_hooks` (parametrized) verifies subcommands, settings, health_checks hooks
- [x] All existing tests still pass
