### PR TITLE
Add `--force` flag to `conda self remove`

### DIFF
--- a/conda_self/cli/main_remove.py
+++ b/conda_self/cli/main_remove.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -13,6 +14,15 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
 
     parser.description = HELP
     add_output_and_prompt_options(parser)
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Remove packages even when they are listed as permanent "
+            "(hard-coded or via `self_permanent_packages`). "
+            "Confirmation is still required unless `--yes` is passed."
+        ),
+    )
     parser.add_argument("specs", nargs="+", help="Plugins to remove/uninstall")
     parser.set_defaults(func=execute)
 
@@ -26,13 +36,18 @@ def execute(args: argparse.Namespace) -> int:
     from ..query import permanent_dependencies
 
     uninstallable_packages = permanent_dependencies(add_plugins=False)
-    invalid_specs = []
-    for spec in args.specs:
-        if spec in uninstallable_packages:
-            invalid_specs.append(spec)
+    protected_specs = [spec for spec in args.specs if spec in uninstallable_packages]
 
-    if invalid_specs:
-        raise PluginRemoveError(invalid_specs)
+    if protected_specs and not args.force:
+        raise PluginRemoveError(protected_specs)
+
+    if protected_specs:
+        print(
+            "Warning: the following packages are configured as permanent "
+            "and will be removed because `--force` was passed:",
+            ", ".join(protected_specs),
+            file=sys.stderr,
+        )
 
     print("Removing plugins:", *args.specs)
 

--- a/news/127-force-remove
+++ b/news/127-force-remove
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add `--force` flag to `conda self remove` to override permanent package protection (both the hard-coded `conda`/`conda-self` list and packages configured via `self_permanent_packages`). Confirmation is still required unless `--yes` is passed. (#127)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_cli_remove.py
+++ b/tests/test_cli_remove.py
@@ -14,36 +14,58 @@ if TYPE_CHECKING:
     from pytest import MonkeyPatch
 
 
-def test_help(conda_cli):
+def test_help(conda_cli: CondaCLIFixture) -> None:
     out, err, exc = conda_cli("self", "remove", "--help", raises=SystemExit)
     assert exc.value.code == 0
 
 
 @pytest.mark.parametrize(
-    "spec,error",
+    "spec,force,raises",
     (
-        ("conda", PluginRemoveError),
-        ("conda-libmamba-solver", PluginRemoveError),
-        ("python", PluginRemoveError),
+        ("conda", False, PluginRemoveError),
+        ("conda-libmamba-solver", False, PluginRemoveError),
+        ("python", False, PluginRemoveError),
+        ("conda", True, None),
+        ("conda-libmamba-solver", True, None),
+        ("python", True, None),
+        ("flask", False, None),
+        ("flask", True, None),
     ),
 )
-def test_remove_protected_plugin(conda_cli, spec, error):
-    conda_cli(
-        "self",
-        "remove",
-        spec,
-        raises=error,
-    )
+def test_remove_validation(
+    conda_cli: CondaCLIFixture,
+    spec: str,
+    force: bool,
+    raises: type[Exception] | None,
+) -> None:
+    """Validation guard for permanent specs, overridden by ``--force``."""
+    argv = ["self", "remove", "--yes", spec]
+    if force:
+        argv.insert(2, "--force")
+
+    if raises is not None:
+        conda_cli(*argv, raises=raises)
+    else:
+        conda_cli(*argv)
 
 
-def test_remove_unprotected_plugin_passes_validation(conda_cli):
-    """Verify non-essential specs pass validation and reach the confirmation prompt."""
-    conda_cli(
-        "self",
-        "remove",
-        "--yes",
-        "flask",
-    )
+@pytest.mark.parametrize(
+    "spec,expect_warning",
+    (
+        ("conda", True),
+        ("conda-libmamba-solver", True),
+        ("python", True),
+        ("flask", False),
+    ),
+)
+def test_force_warning_message(
+    conda_cli: CondaCLIFixture,
+    spec: str,
+    expect_warning: bool,
+) -> None:
+    """``--force`` warns to stderr only when overriding permanent specs."""
+    _out, err, _exc = conda_cli("self", "remove", "--yes", "--force", spec)
+    assert ("Warning" in err and spec in err and "--force" in err) is expect_warning
 
 
 def test_remove_nonessential_plugin(
@@ -51,7 +73,7 @@ def test_remove_nonessential_plugin(
     monkeypatch: MonkeyPatch,
     base_env: Path,
     conda_channel: str,
-):
+) -> None:
     monkeypatch.setenv("CONDA_CHANNELS", conda_channel)
 
     conda_cli("install", "conda-index", "--yes", "--prefix", base_env)


### PR DESCRIPTION
Closes #127.

Adds a `--force` flag to `conda self remove` that bypasses the permanent package check, for both the hard-coded `PERMANENT_PACKAGES` (`conda`, `conda-self`) and anything configured via `self_permanent_packages`.

Behavior:

- Without `--force`: existing `PluginRemoveError` is raised for any protected spec (unchanged).
- With `--force` + protected spec(s): proceed, but print a stderr warning naming the overridden specs so it's obvious what was force-removed.
- Confirmation prompt is still shown unless `--yes` is also passed.

Example:

```
$ conda self remove anaconda-anon-usage
PluginRemoveError: Packages '['anaconda-anon-usage']' can not be removed.

$ conda self remove --force --yes anaconda-anon-usage
Warning: the following packages are configured as permanent and will be removed because `--force` was passed: anaconda-anon-usage
Removing plugins: anaconda-anon-usage
...
```

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda-incubator/conda-self/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~