### PR TITLE
Improve frozen base guidance

### DIFF
--- a/conda_self/health_checks/base_protection.py
+++ b/conda_self/health_checks/base_protection.py
@@ -18,6 +18,13 @@ if TYPE_CHECKING:
     from conda.plugins.types import ConfirmCallback
 
 
+BASE_PROTECTION_FROZEN_MESSAGE = """\
+Your base environment is protected from direct modifications.
+
+To manage conda and its plugins, use conda self:
+  conda self --help"""
+
+
 def is_base_environment(prefix: str) -> bool:
     """Check if the given prefix is the base environment."""
     return prefix == sys.prefix
@@ -80,7 +87,7 @@ def fix(prefix: str, args: Namespace, confirm: ConfirmCallback) -> int:
     from ..reset import names_from_explicit, reset
 
     default_env = DEFAULT_ENV_NAME
-    message = "Protected by Base Environment Protection health fix"
+    message = BASE_PROTECTION_FROZEN_MESSAGE
 
     base_prefix = Path(sys.prefix)
 

--- a/tests/test_health_check_base_protection.py
+++ b/tests/test_health_check_base_protection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from argparse import Namespace
 from typing import TYPE_CHECKING
@@ -9,7 +10,7 @@ from typing import TYPE_CHECKING
 import pytest
 from conda.base.constants import PREFIX_FROZEN_FILE
 from conda.core.prefix_data import PrefixData
-from conda.exceptions import CondaValueError
+from conda.exceptions import CondaValueError, EnvironmentIsFrozenError
 
 from conda_self.constants import RESET_FILE_INSTALLER
 from conda_self.health_checks import base_protection
@@ -258,6 +259,18 @@ def test_fix_reset_strategy(
     assert "snapshot" not in reset_calls[0]
     assert expected_keep <= reset_calls[0]["uninstallable_packages"]
     assert len(perm_deps_calls) == 1
+
+
+def test_fix_writes_actionable_frozen_message(fixable_base_env: Path):
+    base_protection.fix(str(fixable_base_env), Namespace(), lambda msg: None)
+
+    frozen_file = fixable_base_env / PREFIX_FROZEN_FILE
+    frozen_message = json.loads(frozen_file.read_text())["message"]
+    rendered_error = str(EnvironmentIsFrozenError(fixable_base_env, frozen_message))
+
+    assert frozen_message == base_protection.BASE_PROTECTION_FROZEN_MESSAGE
+    assert "conda self --help" in rendered_error
+    assert "--override-frozen" in rendered_error
 
 
 def test_health_check_registered():


### PR DESCRIPTION
## Summary

- Replace the base-protection frozen marker reason with actionable guidance that explains direct base modifications are protected and points users to `conda self --help`.
- Add coverage that renders `EnvironmentIsFrozenError` so the message includes the new `conda self` guidance while conda still appends its generic `--override-frozen` warning.

Fixes #139.

## Tests

- `pixi run --environment test-py312 test tests/test_health_check_base_protection.py -vv`
- `pixi run --environment test-py312 ruff check conda_self/health_checks/base_protection.py tests/test_health_check_base_protection.py`
- `pixi run --environment test-py312 ruff format --check conda_self/health_checks/base_protection.py tests/test_health_check_base_protection.py`
- `git diff --check`
