### PR TITLE
Add installer adapters for self update and uninstall

### DIFF
--- a/conda_self/cli/__init__.py
+++ b/conda_self/cli/__init__.py
@@ -16,6 +16,8 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
     from .main_remove import configure_parser as configure_parser_remove
     from .main_reset import HELP as RESET_HELP
     from .main_reset import configure_parser as configure_parser_reset
+    from .main_uninstall import HELP as UNINSTALL_HELP
+    from .main_uninstall import configure_parser as configure_parser_uninstall
     from .main_update import HELP as UPDATE_HELP
     from .main_update import configure_parser as configure_parser_update
 
@@ -35,6 +37,7 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
     configure_parser_install(subparsers.add_parser("install", help=INSTALL_HELP))
     configure_parser_remove(subparsers.add_parser("remove", help=REMOVE_HELP))
     configure_parser_reset(subparsers.add_parser("reset", help=RESET_HELP))
+    configure_parser_uninstall(subparsers.add_parser("uninstall", help=UNINSTALL_HELP))
     configure_parser_update(subparsers.add_parser("update", help=UPDATE_HELP))
     parser.set_defaults(func=partial(parser.parse_args, ["--help"]))
 

--- a/conda_self/cli/main_uninstall.py
+++ b/conda_self/cli/main_uninstall.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+HELP = "Uninstall this conda installation using its installer adapter."
+
+
+def configure_parser(parser: argparse.ArgumentParser) -> None:
+    from conda.cli.helpers import add_output_and_prompt_options
+
+    parser.description = HELP
+    add_output_and_prompt_options(parser)
+    parser.set_defaults(func=execute)
+
+
+def execute(args: argparse.Namespace) -> int:
+    from pathlib import Path
+
+    from conda.base.context import context
+
+    from ..exceptions import InstallerOperationUnsupportedError
+    from ..models import UninstallRequest
+    from ..registry import get_adapter
+
+    prefix = Path(context.root_prefix)
+    adapter = get_adapter(prefix)
+    if adapter is None or adapter.uninstall is None:
+        raise InstallerOperationUnsupportedError("uninstall", prefix)
+
+    return adapter.uninstall(
+        UninstallRequest(
+            prefix=prefix,
+            dry_run=context.dry_run or bool(args.dry_run),
+            yes=context.always_yes or bool(args.yes),
+            json=context.json or bool(args.json),
+            quiet=context.quiet or bool(args.quiet),
+        )
+    )

--- a/conda_self/cli/main_uninstall.py
+++ b/conda_self/cli/main_uninstall.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import argparse
 
-HELP = "Uninstall this conda installation using its installer adapter."
+HELP = "Uninstall this conda installation through its installer or package manager."
 
 
 def configure_parser(parser: argparse.ArgumentParser) -> None:

--- a/conda_self/cli/main_update.py
+++ b/conda_self/cli/main_update.py
@@ -33,11 +33,15 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
 
 
 def execute(args: argparse.Namespace) -> int:
+    from pathlib import Path
+
     from conda.base.context import context
     from conda.core.prefix_data import PrefixData
     from conda.exceptions import PackageNotInstalledError
 
     from ..install import install_specs_in_protected_env
+    from ..models import LauncherUpdateRequest
+    from ..registry import get_adapter
     from ..validate import conda_plugin_packages, validate_plugin_is_installed
 
     if args.plugin:
@@ -46,6 +50,19 @@ def execute(args: argparse.Namespace) -> int:
     elif args.all:
         package_names = ["conda", *conda_plugin_packages()]
     else:
+        prefix = Path(context.root_prefix)
+        adapter = get_adapter(prefix)
+        if adapter is not None and adapter.update_launcher is not None:
+            return adapter.update_launcher(
+                LauncherUpdateRequest(
+                    prefix=prefix,
+                    force_reinstall=args.force_reinstall,
+                    dry_run=context.dry_run or bool(args.dry_run),
+                    yes=context.always_yes or bool(args.yes),
+                    json=context.json or bool(args.json),
+                    quiet=context.quiet or bool(args.quiet),
+                )
+            )
         package_names = ["conda"]
 
     prefix_data = PrefixData(context.root_prefix)

--- a/conda_self/exceptions.py
+++ b/conda_self/exceptions.py
@@ -34,3 +34,31 @@ class NoDistInfoDirFound(CondaError):
         super().__init__(
             f"No *.dist-info directories found for '{package_name}' in '{path}'."
         )
+
+
+class InstallerAdapterError(CondaError):
+    """Base class for installer adapter errors."""
+
+
+class InvalidInstallerAdapterError(InstallerAdapterError):
+    def __init__(self, adapter: object):
+        super().__init__(
+            "conda_self_adapters() must yield CondaSelfAdapter objects, "
+            f"got {adapter!r}"
+        )
+
+
+class MultipleInstallerAdaptersError(InstallerAdapterError):
+    def __init__(self, prefix: Path, names: list[str]):
+        super().__init__(
+            f"Multiple installer adapters claim '{prefix}': {', '.join(names)}"
+        )
+
+
+class InstallerOperationUnsupportedError(InstallerAdapterError):
+    def __init__(self, operation: str, prefix: Path):
+        super().__init__(
+            f"The conda installation at '{prefix}' does not provide "
+            f"installer-owned {operation} support. Use the installer or package "
+            "manager that installed this conda distribution."
+        )

--- a/conda_self/exceptions.py
+++ b/conda_self/exceptions.py
@@ -58,7 +58,6 @@ class MultipleInstallerAdaptersError(InstallerAdapterError):
 class InstallerOperationUnsupportedError(InstallerAdapterError):
     def __init__(self, operation: str, prefix: Path):
         super().__init__(
-            f"The conda installation at '{prefix}' does not provide "
-            f"installer-owned {operation} support. Use the installer or package "
-            "manager that installed this conda distribution."
+            f"Cannot {operation} the conda installation at '{prefix}'. "
+            "Use the installer or package manager that installed it."
         )

--- a/conda_self/hookspec.py
+++ b/conda_self/hookspec.py
@@ -1,0 +1,26 @@
+"""Private Pluggy hooks owned by conda-self."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pluggy
+
+PROJECT_NAME = "conda_self"
+ENTRY_POINT_GROUP = "conda_self"
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+    from .models import CondaSelfAdapter
+
+
+hookspec = pluggy.HookspecMarker(PROJECT_NAME)
+hookimpl = pluggy.HookimplMarker(PROJECT_NAME)
+
+
+@hookspec
+def conda_self_adapters(prefix: Path) -> Iterable[CondaSelfAdapter]:
+    """Return an installer adapter when this package owns ``prefix``."""
+    raise NotImplementedError

--- a/conda_self/hookspec.py
+++ b/conda_self/hookspec.py
@@ -22,5 +22,5 @@ hookimpl = pluggy.HookimplMarker(PROJECT_NAME)
 
 @hookspec
 def conda_self_adapters(prefix: Path) -> Iterable[CondaSelfAdapter]:
-    """Return an installer adapter when this package owns ``prefix``."""
+    """Yield an adapter for ``prefix`` when this provider recognizes it."""
     raise NotImplementedError

--- a/conda_self/models.py
+++ b/conda_self/models.py
@@ -1,0 +1,48 @@
+"""Public models for conda-self installer adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+
+@dataclass(frozen=True)
+class UninstallRequest:
+    """Context passed to an installer-owned uninstall operation."""
+
+    prefix: Path
+    dry_run: bool = False
+    yes: bool = False
+    json: bool = False
+    quiet: bool = False
+
+
+@dataclass(frozen=True)
+class LauncherUpdateRequest:
+    """Context passed to an installer-owned launcher update operation."""
+
+    prefix: Path
+    force_reinstall: bool = False
+    dry_run: bool = False
+    yes: bool = False
+    json: bool = False
+    quiet: bool = False
+
+
+@dataclass(frozen=True)
+class CondaSelfAdapter:
+    """Distribution-owned implementations for conda-self operations."""
+
+    name: str
+    uninstall: Callable[[UninstallRequest], int] | None = None
+    update_launcher: Callable[[LauncherUpdateRequest], int] | None = None
+
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise ValueError("Adapter name must not be empty")
+        if self.uninstall is None and self.update_launcher is None:
+            raise ValueError("Adapter must implement at least one operation")

--- a/conda_self/models.py
+++ b/conda_self/models.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class UninstallRequest:
-    """Context passed to an installer-owned uninstall operation."""
+    """Arguments passed to the uninstall callback."""
 
     prefix: Path
     dry_run: bool = False
@@ -23,7 +23,7 @@ class UninstallRequest:
 
 @dataclass(frozen=True)
 class LauncherUpdateRequest:
-    """Context passed to an installer-owned launcher update operation."""
+    """Arguments passed to the launcher update callback."""
 
     prefix: Path
     force_reinstall: bool = False
@@ -35,7 +35,7 @@ class LauncherUpdateRequest:
 
 @dataclass(frozen=True)
 class CondaSelfAdapter:
-    """Distribution-owned implementations for conda-self operations."""
+    """Installer callbacks for uninstalling a prefix or updating its launcher."""
 
     name: str
     uninstall: Callable[[UninstallRequest], int] | None = None

--- a/conda_self/registry.py
+++ b/conda_self/registry.py
@@ -1,0 +1,54 @@
+"""Discovery for distribution-owned conda-self adapters."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pluggy
+
+from .exceptions import InvalidInstallerAdapterError, MultipleInstallerAdaptersError
+from .hookspec import ENTRY_POINT_GROUP, PROJECT_NAME
+from .models import CondaSelfAdapter
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+class AdapterRegistry(pluggy.PluginManager):
+    """Pluggy manager for the private conda-self adapter group."""
+
+    def __init__(self) -> None:
+        super().__init__(PROJECT_NAME)
+        from . import hookspec as conda_self_hookspec
+
+        self.add_hookspecs(conda_self_hookspec)
+
+    @classmethod
+    def discover(cls) -> AdapterRegistry:
+        """Load adapters from the private conda-self entry-point group."""
+        registry = cls()
+        registry.load_setuptools_entrypoints(ENTRY_POINT_GROUP)
+        return registry
+
+    def applicable(self, prefix: Path) -> CondaSelfAdapter | None:
+        """Return the one adapter that claims ``prefix``, if any."""
+        adapters = list(self._collect(prefix))
+        if len(adapters) > 1:
+            raise MultipleInstallerAdaptersError(
+                prefix=prefix,
+                names=sorted(adapter.name for adapter in adapters),
+            )
+        return adapters[0] if adapters else None
+
+    def _collect(self, prefix: Path) -> Iterable[CondaSelfAdapter]:
+        for result in self.hook.conda_self_adapters(prefix=prefix):
+            for adapter in result or ():
+                if not isinstance(adapter, CondaSelfAdapter):
+                    raise InvalidInstallerAdapterError(adapter)
+                yield adapter
+
+
+def get_adapter(prefix: str | Path) -> CondaSelfAdapter | None:
+    """Discover the installer adapter for ``prefix``."""
+    return AdapterRegistry.discover().applicable(Path(prefix))

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,6 +113,7 @@ guides/custom-channels
 :caption: Reference
 
 reference/cli
+reference/installer-adapters
 configuration
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -118,16 +118,15 @@ operations always use conda package management.
 
 ## self uninstall
 
-Ask the installer that owns this conda distribution to uninstall it.
+Uninstall the conda installation through its installer or package manager.
 
 ```
 conda self uninstall [--dry-run] [--yes] [--json] [--quiet]
 ```
 
-The command delegates to a distribution-provided
-[installer adapter](installer-adapters). The adapter owns confirmation,
-cleanup, and any package-manager guidance. conda-self refuses the operation
-when no adapter provides uninstall support.
+An [installer adapter](installer-adapters) handles confirmation, cleanup, and
+package-manager instructions. If no adapter supports uninstalling the root
+prefix, the command exits without removing it.
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -74,15 +74,17 @@ conda self remove conda-index
 
 ## self update
 
-Update conda and its plugins in the base environment.
+Update the conda installation or its plugins.
 
 ```
-conda self update [<specs>...] [--force-reinstall] [--dry-run] [--yes] [--json] [--quiet]
+conda self update [--plugin <name> | --all] [--force-reinstall] [--dry-run] [--yes] [--json] [--quiet]
 ```
 
-`specs`
-: Optional package names to update. If omitted, updates all plugins
-  and conda itself.
+`--plugin`
+: Update one installed conda plugin together with conda.
+
+`--all`
+: Update conda, all installed conda plugins, and dependencies.
 
 `--force-reinstall`
 : Force reinstall of all packages.
@@ -94,19 +96,38 @@ conda self update [<specs>...] [--force-reinstall] [--dry-run] [--yes] [--json] 
 : Skip confirmation prompts.
 
 ```bash
-# Update everything
+# Update the installation
 conda self update
 
-# Update specific packages
-conda self update conda
+# Update one plugin
+conda self update --plugin conda-index
 
-# Force reinstall all
+# Update all plugins and dependencies
+conda self update --all
+
+# Force reinstall
 conda self update --force-reinstall
 ```
 
-The update command uses `--update-specs` by default and `--all` when
-`--force-reinstall` is specified. It lets the solver find the latest
-compatible versions rather than pinning to specific version numbers.
+A distribution-provided [installer adapter](installer-adapters) may handle a
+bare `conda self update` when it owns the launcher. Without one, the command
+updates the `conda` package in base as before. Explicit `--plugin` and `--all`
+operations always use conda package management.
+
+---
+
+## self uninstall
+
+Ask the installer that owns this conda distribution to uninstall it.
+
+```
+conda self uninstall [--dry-run] [--yes] [--json] [--quiet]
+```
+
+The command delegates to a distribution-provided
+[installer adapter](installer-adapters). The adapter owns confirmation,
+cleanup, and any package-manager guidance. conda-self refuses the operation
+when no adapter provides uninstall support.
 
 ---
 

--- a/docs/reference/installer-adapters.md
+++ b/docs/reference/installer-adapters.md
@@ -1,16 +1,13 @@
 # Installer adapters
 
-Some `conda self` operations depend on how the conda distribution was
-installed. Removing a Constructor installation, updating a standalone
-launcher, and updating an installation owned by a system package manager
-require different policy.
+Some `conda self` commands must use the installer that created the root prefix.
+Constructor, standalone, and system-package-manager installations cannot all be
+updated or removed the same way.
 
-conda-self discovers that policy through its private `conda_self` Pluggy
-entry-point group. Distribution packages can provide one adapter for a root
-prefix. The adapter can implement uninstall, launcher update, or both.
-
-This is separate from conda's plugin API. It is loaded only for operations
-that may belong to an installer adapter.
+conda-self loads providers from its private `conda_self` Pluggy entry-point
+group. A provider yields an adapter when it recognizes the root prefix. The
+adapter can implement uninstall, launcher update, or both. This interface does
+not use conda's plugin API.
 
 ## Provider entry point
 
@@ -52,15 +49,15 @@ multiple adapters claim the same installation.
 
 ## Operations
 
-`uninstall` receives an `UninstallRequest`. The adapter owns the removal plan,
-confirmation, cleanup, and any package-manager guidance. If no applicable
-adapter implements it, `conda self uninstall` refuses to guess how to remove
-the installation.
+`uninstall` receives an `UninstallRequest`. Its callback decides what to remove,
+handles confirmation and cleanup, and can print package-manager instructions.
+If no applicable adapter provides the callback, `conda self uninstall` exits
+without removing the installation.
 
-`update_launcher` receives a `LauncherUpdateRequest`. When present, it handles
-a bare `conda self update`. An externally managed adapter can refuse the update
-and show the exact command for the owning package manager. An adapter for a
-standalone installation can update its launcher.
+`update_launcher` receives a `LauncherUpdateRequest` and handles a bare
+`conda self update`. A package-manager adapter can reject the update and print
+the command users should run instead. A standalone adapter can replace its
+launcher.
 
 Explicit package operations do not call `update_launcher`:
 

--- a/docs/reference/installer-adapters.md
+++ b/docs/reference/installer-adapters.md
@@ -1,0 +1,73 @@
+# Installer adapters
+
+Some `conda self` operations depend on how the conda distribution was
+installed. Removing a Constructor installation, updating a standalone
+launcher, and updating an installation owned by a system package manager
+require different policy.
+
+conda-self discovers that policy through its private `conda_self` Pluggy
+entry-point group. Distribution packages can provide one adapter for a root
+prefix. The adapter can implement uninstall, launcher update, or both.
+
+This is separate from conda's plugin API. It is loaded only for operations
+that may belong to an installer adapter.
+
+## Provider entry point
+
+Register the provider module in `pyproject.toml`:
+
+```toml
+[project.entry-points.conda_self]
+my-distribution = "my_distribution.conda_self"
+```
+
+The provider yields an adapter only when it owns the requested prefix:
+
+```python
+from conda_self.hookspec import hookimpl
+from conda_self.models import CondaSelfAdapter
+
+
+def uninstall(request):
+    ...
+
+
+def update_launcher(request):
+    ...
+
+
+@hookimpl
+def conda_self_adapters(prefix):
+    if not (prefix / ".my-distribution").is_file():
+        return
+    yield CondaSelfAdapter(
+        name="my-distribution",
+        uninstall=uninstall,
+        update_launcher=update_launcher,
+    )
+```
+
+At most one adapter may claim a root prefix. conda-self raises an error if
+multiple adapters claim the same installation.
+
+## Operations
+
+`uninstall` receives an `UninstallRequest`. The adapter owns the removal plan,
+confirmation, cleanup, and any package-manager guidance. If no applicable
+adapter implements it, `conda self uninstall` refuses to guess how to remove
+the installation.
+
+`update_launcher` receives a `LauncherUpdateRequest`. When present, it handles
+a bare `conda self update`. An externally managed adapter can refuse the update
+and show the exact command for the owning package manager. An adapter for a
+standalone installation can update its launcher.
+
+Explicit package operations do not call `update_launcher`:
+
+```bash
+conda self update --plugin conda-build
+conda self update --all
+```
+
+Without an applicable launcher update adapter, a bare `conda self update`
+keeps its existing behavior and updates the `conda` package in base.

--- a/news/158-installer-adapters
+++ b/news/158-installer-adapters
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Add a private Pluggy adapter interface for installer-owned uninstall and launcher updates. (#158)
+* Add a private Pluggy interface that lets distribution packages implement `conda self uninstall` and handle bare `conda self update`. (#158)
 
 ### Bug fixes
 

--- a/news/158-installer-adapters
+++ b/news/158-installer-adapters
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add a private Pluggy adapter interface for installer-owned uninstall and launcher updates. (#158)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Document installer adapter discovery and the `conda self uninstall` command. (#158)
+
+### Other
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 ]
 dependencies = [
   # "conda >=26.1.1",  # not on PyPI, installed via conda
+  "pluggy >=1.5",
 ]
 dynamic = ["version"]
 

--- a/tests/test_cli_uninstall.py
+++ b/tests/test_cli_uninstall.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from conda_self.exceptions import InstallerOperationUnsupportedError
+from conda_self.models import CondaSelfAdapter
+
+if TYPE_CHECKING:
+    from conda.testing.fixtures import CondaCLIFixture
+    from pytest import MonkeyPatch
+
+
+def test_help(conda_cli: CondaCLIFixture) -> None:
+    _out, _err, exc = conda_cli("self", "uninstall", "--help", raises=SystemExit)
+    assert exc.value.code == 0
+
+
+def test_uninstall_requires_adapter(
+    conda_cli: CondaCLIFixture,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("conda_self.registry.get_adapter", lambda prefix: None)
+
+    conda_cli("self", "uninstall", "--yes", raises=InstallerOperationUnsupportedError)
+
+
+def test_uninstall_dispatches_to_adapter(
+    conda_cli: CondaCLIFixture,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    requests = []
+
+    def uninstall(request) -> int:
+        requests.append(request)
+        return 0
+
+    adapter = CondaSelfAdapter(name="test", uninstall=uninstall)
+    monkeypatch.setattr("conda_self.registry.get_adapter", lambda prefix: adapter)
+
+    conda_cli("self", "uninstall", "--yes", "--dry-run", "--quiet")
+
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.prefix.is_absolute()
+    assert request.dry_run is True
+    assert request.yes is True
+    assert request.quiet is True
+
+
+def test_uninstall_requires_adapter_capability(
+    conda_cli: CondaCLIFixture,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    adapter = CondaSelfAdapter(name="test", update_launcher=lambda request: 0)
+    monkeypatch.setattr("conda_self.registry.get_adapter", lambda prefix: adapter)
+
+    conda_cli("self", "uninstall", "--yes", raises=InstallerOperationUnsupportedError)

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 from conda.exceptions import CondaValueError
 
+from conda_self.models import CondaSelfAdapter
 from conda_self.testing import conda_cli_subprocess
 
 if TYPE_CHECKING:
@@ -21,6 +22,30 @@ def test_help(conda_cli: CondaCLIFixture):
 
 def test_update_plugin_invalid(conda_cli: CondaCLIFixture):
     conda_cli("self", "update", "--plugin", "conda-fake-solver", raises=CondaValueError)
+
+
+def test_bare_update_dispatches_to_installer_adapter(
+    conda_cli: CondaCLIFixture,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    requests = []
+
+    def update_launcher(request) -> int:
+        requests.append(request)
+        return 0
+
+    adapter = CondaSelfAdapter(name="test", update_launcher=update_launcher)
+    monkeypatch.setattr("conda_self.registry.get_adapter", lambda prefix: adapter)
+
+    conda_cli("self", "update", "--force-reinstall", "--dry-run", "--yes", "--quiet")
+
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.prefix.is_absolute()
+    assert request.force_reinstall is True
+    assert request.dry_run is True
+    assert request.yes is True
+    assert request.quiet is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pluggy
+import pytest
+
+from conda_self.exceptions import (
+    InvalidInstallerAdapterError,
+    MultipleInstallerAdaptersError,
+)
+from conda_self.hookspec import ENTRY_POINT_GROUP, hookimpl
+from conda_self.models import CondaSelfAdapter
+from conda_self.registry import AdapterRegistry
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def uninstall(_request) -> int:
+    return 0
+
+
+def test_registry_is_private_pluggy_manager() -> None:
+    registry = AdapterRegistry()
+
+    assert isinstance(registry, pluggy.PluginManager)
+    assert hasattr(registry.hook, "conda_self_adapters")
+
+
+def test_discover_uses_private_entry_point_group(monkeypatch) -> None:
+    groups: list[str] = []
+
+    def load_entry_points(self, group: str) -> int:
+        groups.append(group)
+        return 0
+
+    monkeypatch.setattr(
+        pluggy.PluginManager,
+        "load_setuptools_entrypoints",
+        load_entry_points,
+    )
+
+    AdapterRegistry.discover()
+
+    assert groups == [ENTRY_POINT_GROUP]
+
+
+def test_registry_collects_adapter_for_claimed_prefix(tmp_path: Path) -> None:
+    claimed = tmp_path / "claimed"
+
+    class Provider:
+        @hookimpl
+        def conda_self_adapters(self, prefix: Path):
+            if prefix == claimed:
+                yield CondaSelfAdapter(name="test", uninstall=uninstall)
+
+    registry = AdapterRegistry()
+    registry.register(Provider(), name="provider")
+
+    assert registry.applicable(tmp_path) is None
+    adapter = registry.applicable(claimed)
+    assert adapter is not None
+    assert adapter.name == "test"
+
+
+def test_registry_rejects_invalid_adapter(tmp_path: Path) -> None:
+    class Provider:
+        @hookimpl
+        def conda_self_adapters(self, prefix: Path):
+            yield "not-an-adapter"
+
+    registry = AdapterRegistry()
+    registry.register(Provider(), name="provider")
+
+    with pytest.raises(InvalidInstallerAdapterError):
+        registry.applicable(tmp_path)
+
+
+def test_registry_rejects_multiple_applicable_adapters(tmp_path: Path) -> None:
+    class FirstProvider:
+        @hookimpl
+        def conda_self_adapters(self, prefix: Path):
+            yield CondaSelfAdapter(name="first", uninstall=uninstall)
+
+    class SecondProvider:
+        @hookimpl
+        def conda_self_adapters(self, prefix: Path):
+            yield CondaSelfAdapter(name="second", uninstall=uninstall)
+
+    registry = AdapterRegistry()
+    registry.register(FirstProvider(), name="first-provider")
+    registry.register(SecondProvider(), name="second-provider")
+
+    with pytest.raises(MultipleInstallerAdaptersError, match="first, second"):
+        registry.applicable(tmp_path)
+
+
+def test_adapter_requires_name_and_operation() -> None:
+    with pytest.raises(ValueError, match="name"):
+        CondaSelfAdapter(name="", uninstall=uninstall)
+    with pytest.raises(ValueError, match="operation"):
+        CondaSelfAdapter(name="test")


### PR DESCRIPTION
## Summary

- add the private `conda_self` Pluggy group for installer adapter providers
- add request objects for uninstall and launcher-update callbacks
- let an adapter handle bare `conda self update` when it recognizes the root prefix
- keep updating the `conda` package when no adapter applies
- keep `--plugin` and `--all` updates in conda package management

Closes #158
Advances #125

### Checklist - did you ...

- [x] Add a file to the `news` directory for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
