### PR TITLE
Preserve JSON and quiet output in conda self update

### DIFF
--- a/conda_self/cli/main_update.py
+++ b/conda_self/cli/main_update.py
@@ -57,7 +57,7 @@ def execute(args: argparse.Namespace) -> int:
             raise PackageNotInstalledError(context.root_prefix, name)
         info_parts.append(f"{name} (installed: {installed.version})")
 
-    if not context.quiet:
+    if not context.json and not context.quiet:
         print(f"Updating {', '.join(info_parts)}...")
 
     return install_specs_in_protected_env(
@@ -67,4 +67,5 @@ def execute(args: argparse.Namespace) -> int:
         dry_run=context.dry_run,
         json=context.json,
         yes=context.always_yes,
+        quiet=context.quiet,
     )

--- a/conda_self/cli/main_update.py
+++ b/conda_self/cli/main_update.py
@@ -57,7 +57,8 @@ def execute(args: argparse.Namespace) -> int:
             raise PackageNotInstalledError(context.root_prefix, name)
         info_parts.append(f"{name} (installed: {installed.version})")
 
-    if not context.json and not context.quiet:
+    quiet = context.quiet or bool(args.quiet)
+    if not context.json and not quiet:
         print(f"Updating {', '.join(info_parts)}...")
 
     return install_specs_in_protected_env(
@@ -67,5 +68,5 @@ def execute(args: argparse.Namespace) -> int:
         dry_run=context.dry_run,
         json=context.json,
         yes=context.always_yes,
-        quiet=context.quiet,
+        quiet=quiet,
     )

--- a/conda_self/install.py
+++ b/conda_self/install.py
@@ -11,6 +11,7 @@ def install_specs_in_protected_env(
     dry_run: bool = False,
     json: bool = False,
     yes: bool = False,
+    quiet: bool = False,
 ) -> int:
     """Install or update specs into the protected base env via subprocess."""
     process = run(
@@ -29,6 +30,7 @@ def install_specs_in_protected_env(
             *(("--dry-run",) if dry_run else ()),
             *(("--json",) if json else ()),
             *(("--yes",) if yes else ()),
+            *(("--quiet",) if quiet else ()),
             "--all" if update_dependencies else "--update-specs",
             *specs,
         ]

--- a/news/160-preserve-update-output
+++ b/news/160-preserve-update-output
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Keep `conda self update --json` output parseable and forward `--quiet` to the child conda process. (#160)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+from subprocess import CompletedProcess
 from typing import TYPE_CHECKING
 
 import pytest
@@ -21,6 +23,45 @@ def test_help(conda_cli: CondaCLIFixture):
 
 def test_update_plugin_invalid(conda_cli: CondaCLIFixture):
     conda_cli("self", "update", "--plugin", "conda-fake-solver", raises=CondaValueError)
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected_flags", "expected_json"),
+    (
+        pytest.param(("--json",), ("--json",), {"success": True}, id="json"),
+        pytest.param(
+            ("--quiet", "--dry-run"),
+            ("--quiet", "--dry-run"),
+            None,
+            id="quiet+dry-run",
+        ),
+    ),
+)
+def test_update_output_options(
+    extra_args: tuple[str, ...],
+    expected_flags: tuple[str, ...],
+    expected_json: dict[str, bool] | None,
+    conda_cli: CondaCLIFixture,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    commands: list[list[str]] = []
+
+    def run(command: list[str]) -> CompletedProcess[str]:
+        commands.append(command)
+        if expected_json is not None:
+            print(json.dumps(expected_json))
+        return CompletedProcess(command, 0)
+
+    monkeypatch.setattr("conda_self.install.run", run)
+
+    out, _err, _exc = conda_cli("self", "update", *extra_args)
+
+    if expected_json is None:
+        assert out == ""
+    else:
+        assert json.loads(out) == expected_json
+    for flag in expected_flags:
+        assert flag in commands[0]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- keep `conda self update --json` stdout as a single JSON document
- forward `--quiet` to the child `conda install` process
- cover both output modes with parameterized regression tests

The command previously printed its own status line before JSON output and dropped quiet mode when constructing the child command.

Closes #160

### Checklist - did you ...

- [x] Add a file to the `news` directory for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~~Add / update outdated documentation?~~
